### PR TITLE
psp and psx games can now be intalled on uma0 or ur0

### DIFF
--- a/pkgi.cpp
+++ b/pkgi.cpp
@@ -874,19 +874,19 @@ int main()
                     pkgi_save_config(config);
                     break;
                 case MenuResultRefreshGames:
-					RefreshGames(config.games_url.c_str(),ModeGames);
+                    RefreshGames(config.games_url.c_str(),ModeGames);
                     break;
                 case MenuResultRefreshUpdates:
-					RefreshGames(config.updates_url.c_str(),ModeUpdates);
+                    RefreshGames(config.updates_url.c_str(),ModeUpdates);
                     break;
                 case MenuResultRefreshDlcs:
-					RefreshGames(config.dlcs_url.c_str(),ModeDlcs);
+                    RefreshGames(config.dlcs_url.c_str(),ModeDlcs);
                     break;
                 case MenuResultRefreshPsxGames:
-					RefreshGames(config.psx_games_url.c_str(),ModePsxGames);
+                    RefreshGames(config.psx_games_url.c_str(),ModePsxGames);
                     break;
                 case MenuResultRefreshPspGames:
-					RefreshGames(config.psp_games_url.c_str(),ModePspGames);
+                    RefreshGames(config.psp_games_url.c_str(),ModePspGames);
                     break;
                 }
             }

--- a/pkgi.cpp
+++ b/pkgi.cpp
@@ -15,6 +15,8 @@ extern "C" {
 
 #include <stddef.h>
 
+#include "cstring"
+
 #define PKGI_UPDATE_URL \
     "https://api.github.com/repos/blastrock/pkgj/releases/latest"
 
@@ -139,6 +141,13 @@ static void pkgi_friendly_size(char* text, uint32_t textlen, int64_t size)
                 "%.2f " PKGI_UTF8_GB,
                 size / 1024.f / 1024.f / 1024.f);
     }
+}
+
+void RefreshGames(const char* url, Mode set_mode ){
+    current_url = url;
+    state = StateRefreshing;
+    mode = set_mode;
+    pkgi_start_thread("refresh_thread", &pkgi_refresh_thread);
 }
 
 static void pkgi_do_main(Downloader& downloader, pkgi_input* input)
@@ -631,8 +640,14 @@ static void pkgi_do_tail(Downloader& downloader)
     }
     pkgi_draw_text(0, second_line, PKGI_COLOR_TEXT_TAIL, text);
 
+	//get free space of partition only if looking at psx or psp games else show ux
     char size[64];
-    pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space());
+	if(strcmp(current_url,config.psx_games_url.c_str())== 0 || strcmp(current_url,config.psp_games_url.c_str())== 0){
+		pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space(pkgi_get_partition()));
+	}else{
+		pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space("ux0:"));
+	}
+
 
     char free[64];
     pkgi_snprintf(free, sizeof(free), "Free: %s", size);
@@ -859,34 +874,19 @@ int main()
                     pkgi_save_config(config);
                     break;
                 case MenuResultRefreshGames:
-                    current_url = config.games_url.c_str();
-                    state = StateRefreshing;
-                    mode = ModeGames;
-                    pkgi_start_thread("refresh_thread", &pkgi_refresh_thread);
+					RefreshGames(config.games_url.c_str(),ModeGames);
                     break;
                 case MenuResultRefreshUpdates:
-                    current_url = config.updates_url.c_str();
-                    state = StateRefreshing;
-                    mode = ModeUpdates;
-                    pkgi_start_thread("refresh_thread", &pkgi_refresh_thread);
+					RefreshGames(config.updates_url.c_str(),ModeUpdates);
                     break;
                 case MenuResultRefreshDlcs:
-                    current_url = config.dlcs_url.c_str();
-                    state = StateRefreshing;
-                    mode = ModeDlcs;
-                    pkgi_start_thread("refresh_thread", &pkgi_refresh_thread);
+					RefreshGames(config.dlcs_url.c_str(),ModeDlcs);
                     break;
                 case MenuResultRefreshPsxGames:
-                    current_url = config.psx_games_url.c_str();
-                    state = StateRefreshing;
-                    mode = ModePsxGames;
-                    pkgi_start_thread("refresh_thread", &pkgi_refresh_thread);
+					RefreshGames(config.psx_games_url.c_str(),ModePsxGames);
                     break;
                 case MenuResultRefreshPspGames:
-                    current_url = config.psp_games_url.c_str();
-                    state = StateRefreshing;
-                    mode = ModePspGames;
-                    pkgi_start_thread("refresh_thread", &pkgi_refresh_thread);
+					RefreshGames(config.psp_games_url.c_str(),ModePspGames);
                     break;
                 }
             }

--- a/pkgi.cpp
+++ b/pkgi.cpp
@@ -15,7 +15,7 @@ extern "C" {
 
 #include <stddef.h>
 
-#include "cstring"
+#include <cstring>
 
 #define PKGI_UPDATE_URL \
     "https://api.github.com/repos/blastrock/pkgj/releases/latest"
@@ -143,7 +143,7 @@ static void pkgi_friendly_size(char* text, uint32_t textlen, int64_t size)
     }
 }
 
-void RefreshGames(const char* url, Mode set_mode ){
+void refresh_games(const char* url, Mode set_mode ){
     current_url = url;
     state = StateRefreshing;
     mode = set_mode;
@@ -640,13 +640,13 @@ static void pkgi_do_tail(Downloader& downloader)
     }
     pkgi_draw_text(0, second_line, PKGI_COLOR_TEXT_TAIL, text);
 
-	//get free space of partition only if looking at psx or psp games else show ux
+	//get free space of partition only if looking at psx or psp games else show ux0:
     char size[64];
-	if(strcmp(current_url,config.psx_games_url.c_str())== 0 || strcmp(current_url,config.psp_games_url.c_str())== 0){
-		pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space(pkgi_get_partition()));
-	}else{
-		pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space("ux0:"));
-	}
+    if (pkgi_db_get_mode() == ModePsxGames || pkgi_db_get_mode() == ModePspGames){
+	    pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space(pkgi_get_partition()));
+    }else{
+	    pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space("ux0:"));
+    }
 
 
     char free[64];
@@ -874,19 +874,19 @@ int main()
                     pkgi_save_config(config);
                     break;
                 case MenuResultRefreshGames:
-                    RefreshGames(config.games_url.c_str(),ModeGames);
+                    refresh_games(config.games_url.c_str(),ModeGames);
                     break;
                 case MenuResultRefreshUpdates:
-                    RefreshGames(config.updates_url.c_str(),ModeUpdates);
+                    refresh_games(config.updates_url.c_str(),ModeUpdates);
                     break;
                 case MenuResultRefreshDlcs:
-                    RefreshGames(config.dlcs_url.c_str(),ModeDlcs);
+                    refresh_games(config.dlcs_url.c_str(),ModeDlcs);
                     break;
                 case MenuResultRefreshPsxGames:
-                    RefreshGames(config.psx_games_url.c_str(),ModePsxGames);
+                    refresh_games(config.psx_games_url.c_str(),ModePsxGames);
                     break;
                 case MenuResultRefreshPspGames:
-                    RefreshGames(config.psp_games_url.c_str(),ModePspGames);
+                    refresh_games(config.psp_games_url.c_str(),ModePspGames);
                     break;
                 }
             }

--- a/pkgi.cpp
+++ b/pkgi.cpp
@@ -143,7 +143,7 @@ static void pkgi_friendly_size(char* text, uint32_t textlen, int64_t size)
     }
 }
 
-void refresh_games(const char* url, Mode set_mode ){
+static void pkgi_refresh_games(const char* url, Mode set_mode ){
     current_url = url;
     state = StateRefreshing;
     mode = set_mode;
@@ -874,19 +874,19 @@ int main()
                     pkgi_save_config(config);
                     break;
                 case MenuResultRefreshGames:
-                    refresh_games(config.games_url.c_str(),ModeGames);
+                    pkgi_refresh_games(config.games_url.c_str(),ModeGames);
                     break;
                 case MenuResultRefreshUpdates:
-                    refresh_games(config.updates_url.c_str(),ModeUpdates);
+                    pkgi_refresh_games(config.updates_url.c_str(),ModeUpdates);
                     break;
                 case MenuResultRefreshDlcs:
-                    refresh_games(config.dlcs_url.c_str(),ModeDlcs);
+                    pkgi_refresh_games(config.dlcs_url.c_str(),ModeDlcs);
                     break;
                 case MenuResultRefreshPsxGames:
-                    refresh_games(config.psx_games_url.c_str(),ModePsxGames);
+                    pkgi_refresh_games(config.psx_games_url.c_str(),ModePsxGames);
                     break;
                 case MenuResultRefreshPspGames:
-                    refresh_games(config.psp_games_url.c_str(),ModePspGames);
+                    pkgi_refresh_games(config.psp_games_url.c_str(),ModePspGames);
                     break;
                 }
             }

--- a/pkgi.h
+++ b/pkgi.h
@@ -68,9 +68,10 @@ int pkgi_bettery_get_level();
 int pkgi_battery_is_low();
 int pkgi_battery_is_charging();
 
-uint64_t pkgi_get_free_space(void);
+uint64_t pkgi_get_free_space(const char*);
 const char* pkgi_get_config_folder(void);
 const char* pkgi_get_temp_folder(void);
+const char* pkgi_get_partition(void);
 const char* pkgi_get_app_folder(void);
 int pkgi_is_incomplete(const char* titleid);
 int pkgi_is_installed(const char* titleid);

--- a/pkgi_config.cpp
+++ b/pkgi_config.cpp
@@ -117,19 +117,20 @@ Config pkgi_load_config()
     config.filter = DbFilterAll;
     config.no_version_check = 0;
     config.install_psp_as_pbp = 0;
+    config.install_psp_psx_location = "ux0:";
 
     char data[4096];
     char path[256];
     pkgi_snprintf(
             path, sizeof(path), "%s/config.txt", pkgi_get_config_folder());
-    LOG("config location: %s", path);
+    //LOG("config location: %s", path);
 
     int loaded = pkgi_load(path, data, sizeof(data) - 1);
     if (loaded > 0)
     {
         data[loaded] = '\n';
 
-        LOG("config.txt loaded, parsing");
+        //LOG("config.txt loaded, parsing");
         char* text = data;
         char* end = data + loaded + 1;
 
@@ -184,6 +185,8 @@ Config pkgi_load_config()
                 config.no_version_check = 1;
             else if (pkgi_stricmp(key, "install_psp_as_pbp") == 0)
                 config.install_psp_as_pbp = 1;
+            else if (pkgi_stricmp(key, "install_psp_psx_location") == 0)
+                            config.install_psp_psx_location = value;
         }
     }
     else
@@ -257,6 +260,12 @@ void pkgi_save_config(const Config& config)
                 sizeof(data) - len,
                 "url_psp_games %s\n",
                 config.psp_games_url.c_str());
+    if (!config.install_psp_psx_location.empty())
+            len += pkgi_snprintf(
+                    data + len,
+                    sizeof(data) - len,
+                    "install_psp_psx_location %s\n",
+                    config.install_psp_psx_location.c_str());
     len += pkgi_snprintf(
             data + len, sizeof(data) - len, "sort %s\n", sort_str(config.sort));
     len += pkgi_snprintf(

--- a/pkgi_config.cpp
+++ b/pkgi_config.cpp
@@ -123,14 +123,14 @@ Config pkgi_load_config()
     char path[256];
     pkgi_snprintf(
             path, sizeof(path), "%s/config.txt", pkgi_get_config_folder());
-    //LOG("config location: %s", path);
+    LOG("config location: %s", path);
 
     int loaded = pkgi_load(path, data, sizeof(data) - 1);
     if (loaded > 0)
     {
         data[loaded] = '\n';
 
-        //LOG("config.txt loaded, parsing");
+        LOG("config.txt loaded, parsing");
         char* text = data;
         char* end = data + loaded + 1;
 

--- a/pkgi_config.hpp
+++ b/pkgi_config.hpp
@@ -11,6 +11,7 @@ typedef struct Config
     uint32_t filter;
     int no_version_check;
     int install_psp_as_pbp;
+    std::string install_psp_psx_location;
 
     std::string games_url;
     std::string updates_url;

--- a/pkgi_vita.cpp
+++ b/pkgi_vita.cpp
@@ -649,8 +649,8 @@ uint64_t pkgi_get_free_space(const char* requested_partition)
     else
     {
         uint64_t free, max;
-        char* dev= "";
-		strcpy(dev,requested_partition);
+        char dev[16];
+        strncpy(dev, requested_partition, sizeof(dev));
         sceAppMgrGetDevInfo(dev, &max, &free);
         return free;
     }
@@ -814,8 +814,8 @@ void pkgi_install_pspgame(const char* contentid)
     const auto path = fmt::format("{}/{}", pkgi_get_temp_folder(), contentid);
     const auto dest = fmt::format("{}pspemu/PSP/GAME/{:.9}",pkgi_get_partition(), contentid + 7);
 
-    const auto dir = fmt::format("{}pspemu/PSP/GAME",pkgi_get_partition());
-    pkgi_mkdirs((char *)dir.c_str());
+    auto dir = fmt::format("{}pspemu/PSP/GAME",pkgi_get_partition());
+    pkgi_mkdirs(&dir[0]);
 
     LOG("installing psx game at %s to %s", path.c_str(),dest.c_str());
     int res = sceIoRename(path.c_str(), dest.c_str());
@@ -835,8 +835,8 @@ void pkgi_install_pspgame_as_iso(const char* contentid)
     const auto pspkey = fmt::format("{}/PSP-KEY.EDAT", path);
     const auto isodest = fmt::format("{}pspemu/ISO/{:.9}.iso",pkgi_get_partition(), contentid + 7);
 
-    const auto dir = fmt::format("{}pspemu/ISO",pkgi_get_partition());
-    pkgi_mkdirs((char *)dir.c_str());
+    auto dir = fmt::format("{}pspemu/ISO",pkgi_get_partition());
+    pkgi_mkdirs(&dir[0]);
 
 
     LOG("installing psp game at %s to %s", path.c_str(),dest.c_str());

--- a/pkgi_vita.cpp
+++ b/pkgi_vita.cpp
@@ -1,6 +1,7 @@
 extern "C" {
 #include "pkgi.h"
 #include "pkgi_style.h"
+#include "pkgi_db.h"
 }
 #include "pkgi_config.hpp"
 #include "pkgi_http.hpp"
@@ -648,7 +649,7 @@ uint64_t pkgi_get_free_space(const char* requested_partition)
     else
     {
         uint64_t free, max;
-        char* dev= NULL;
+        char* dev= "";
 		strcpy(dev,requested_partition);
         sceAppMgrGetDevInfo(dev, &max, &free);
         return free;
@@ -662,17 +663,21 @@ const char* pkgi_get_config_folder(void)
 
 const char* pkgi_get_temp_folder(void)
 {
-
-	//cant find a proper way to return pkgi_get_partition() + "pkgi" as it goes null when accesed by Download::pkgi_download on pkgi_download.cpp
-	if(strcmp(pkgi_get_partition(),"ux0:") == 0){
-		return "ux0:pkgi";
-	} else if(strcmp(pkgi_get_partition(),"ur0:") == 0){
-		return "ur0:pkgi";
-	} else if(strcmp(pkgi_get_partition(),"uma0:") == 0){
-		return "uma0:pkgi";
-	} else{
-		return "ux0:pkgi";
-	}
+    if (pkgi_db_get_mode() == ModePsxGames || pkgi_db_get_mode() == ModePspGames){
+        //cant find a proper way to return pkgi_get_partition() + "pkgi" as it goes null when accesed by Download::pkgi_download on pkgi_download.cpp
+        LOG("pkgi_get_partition(): %s",pkgi_get_partition());
+        if(strcmp(pkgi_get_partition(),"ux0:") == 0){
+            return "ux0:pkgi";
+        } else if(strcmp(pkgi_get_partition(),"ur0:") == 0){
+            return "ur0:pkgi";
+        } else if(strcmp(pkgi_get_partition(),"uma0:") == 0){
+            return "uma0:pkgi";
+        } else{
+            return "ux0:pkgi";
+        }
+    }else{
+        return "ux0:pkgi";
+    }
 }
 const char* pkgi_get_app_folder(void)
 {

--- a/pkgi_vita.cpp
+++ b/pkgi_vita.cpp
@@ -626,14 +626,18 @@ int pkgi_battery_is_charging()
 
 const char* pkgi_get_partition(void)
 {
+    //function also accesed by pkgi.cpp to show free space of relevant partition
     Config config = pkgi_load_config();
     std::string partition = config.install_psp_psx_location;
     if (partition.empty()) {
         return "ux0:";
+    }else if(strcmp(partition.c_str(),"ur0:") == 0){
+        return "ur0:";
+    } else if(strcmp(partition.c_str(),"uma0:") == 0){
+        return "uma0:";
     }else{
-        return partition.c_str();
+        return "ux0:";
     }
-
 }
 
 uint64_t pkgi_get_free_space(const char* requested_partition)

--- a/pkgi_vita.cpp
+++ b/pkgi_vita.cpp
@@ -626,11 +626,11 @@ int pkgi_battery_is_charging()
 const char* pkgi_get_partition(void)
 {
     Config config = pkgi_load_config();
-    const char* partition = config.install_psp_psx_location.c_str();
-    if ((partition == NULL) || (partition[0] == '\0')) {
+    std::string partition = config.install_psp_psx_location;
+    if (partition.empty()) {
         return "ux0:";
     }else{
-        return partition;
+        return partition.c_str();
     }
 
 }
@@ -648,7 +648,7 @@ uint64_t pkgi_get_free_space(const char* requested_partition)
     else
     {
         uint64_t free, max;
-        char* dev;
+        char* dev= NULL;
 		strcpy(dev,requested_partition);
         sceAppMgrGetDevInfo(dev, &max, &free);
         return free;
@@ -805,13 +805,12 @@ void pkgi_install_update(const char* contentid)
 
 void pkgi_install_pspgame(const char* contentid)
 {
-    LOG("Installing psx game");
+    LOG("Installing a PSP/PSX game");
     const auto path = fmt::format("{}/{}", pkgi_get_temp_folder(), contentid);
     const auto dest = fmt::format("{}pspemu/PSP/GAME/{:.9}",pkgi_get_partition(), contentid + 7);
 
-    const auto mdir = fmt::format("{}pspemu/PSP/GAME",pkgi_get_partition());
-    char* dir = strdup(mdir.c_str());
-    pkgi_mkdirs(dir);
+    const auto dir = fmt::format("{}pspemu/PSP/GAME",pkgi_get_partition());
+    pkgi_mkdirs((char *)dir.c_str());
 
     LOG("installing psx game at %s to %s", path.c_str(),dest.c_str());
     int res = sceIoRename(path.c_str(), dest.c_str());
@@ -831,9 +830,8 @@ void pkgi_install_pspgame_as_iso(const char* contentid)
     const auto pspkey = fmt::format("{}/PSP-KEY.EDAT", path);
     const auto isodest = fmt::format("{}pspemu/ISO/{:.9}.iso",pkgi_get_partition(), contentid + 7);
 
-    const auto mdir = fmt::format("{}pspemu/ISO",pkgi_get_partition());
-    char* dir = strdup(mdir.c_str());
-    pkgi_mkdirs(dir);
+    const auto dir = fmt::format("{}pspemu/ISO",pkgi_get_partition());
+    pkgi_mkdirs((char *)dir.c_str());
 
 
     LOG("installing psp game at %s to %s", path.c_str(),dest.c_str());


### PR DESCRIPTION
Adding "install_psp_psx_location 'partition'" to configuration file
example: install_psp_psx_location uma0:

Free space will show available space on selected partition when looking at psp or psx games download directory will also change acordingly

if there is no "install_psp_psx_location" line on config.txt it will default to ux0: