### PR TITLE
Add support for package id 14

### DIFF
--- a/src/download.cpp
+++ b/src/download.cpp
@@ -23,6 +23,7 @@ enum ContentType
 {
     CONTENT_TYPE_PSX_GAME = 6,
     CONTENT_TYPE_PSP_GAME = 7,
+    CONTENT_TYPE_PSP_GAME_ALT = 14,
     CONTENT_TYPE_PSP_MINI_GAME = 15,
     CONTENT_TYPE_PSV_GAME = 21, // or update
     CONTENT_TYPE_PSV_DLC = 22,
@@ -595,6 +596,7 @@ int Download::download_head(const uint8_t* rif)
             content_type = get32be(head.data() + offset + 8);
             if (content_type != CONTENT_TYPE_PSX_GAME &&
                 content_type != CONTENT_TYPE_PSP_GAME &&
+                content_type != CONTENT_TYPE_PSP_GAME_ALT &&
                 content_type != CONTENT_TYPE_PSP_MINI_GAME &&
                 content_type != CONTENT_TYPE_PSM_GAME &&
                 content_type != CONTENT_TYPE_PSM_GAME_ALT &&
@@ -894,6 +896,7 @@ int Download::download_files(void)
 
         if (content_type == CONTENT_TYPE_PSX_GAME ||
             content_type == CONTENT_TYPE_PSP_GAME ||
+            content_type == CONTENT_TYPE_PSP_GAME_ALT ||
             content_type == CONTENT_TYPE_PSP_MINI_GAME)
         {
             if (item_name == "USRDIR/CONTENT/DOCUMENT.DAT")
@@ -950,6 +953,7 @@ int Download::download_files(void)
             throw DownloadError("pkg file is too small or corrupted");
 
         if (content_type == CONTENT_TYPE_PSP_GAME ||
+            content_type == CONTENT_TYPE_PSP_GAME_ALT ||
             content_type == CONTENT_TYPE_PSP_MINI_GAME)
         {
             if (save_as_iso && item_name == "USRDIR/CONTENT/EBOOT.PBP")


### PR DESCRIPTION
Apparently some PSP games (EU ones it seems?) use 14 instead of 7 as package ID, and this causes an error to be thrown as it's not defined in the code.

One example is Patapon EUR.