### PR TITLE
Partition and PSP install path support

### DIFF
--- a/src/bgdl.hpp
+++ b/src/bgdl.hpp
@@ -13,6 +13,7 @@ enum BgdlType
 
 void pkgi_start_bgdl(
         const int type,
+        const std::string& partition,
         const std::string& title,
         const std::string& url,
         const std::vector<uint8_t>& rif);

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -69,7 +69,7 @@ int refreshlist(int argc, char* argv[])
 
     const auto db = std::make_unique<TitleDatabase>(".");
     db->update(mode, http.get(), argv[3]);
-    db->reload(mode, DbFilterAllRegions, SortBySize, SortDescending, "the", {});
+    db->reload(mode, DbFilterAllRegions, SortBySize, SortDescending, "", "the", {});
     for (unsigned int i = 0; i < db->count(); ++i)
         fmt::print("{}: {}\n", db->get(i)->name, db->get(i)->size);
     fmt::print("{}/{}\n", db->count(), db->total());

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -46,6 +46,8 @@ static constexpr char default_psm_games_url[] = {
         0x6d, 0x2f, 0x74, 0x73, 0x76, 0x2f, 0x50, 0x53, 0x4d, 0x5f, 0x47,
         0x41, 0x4d, 0x45, 0x53, 0x2e, 0x74, 0x73, 0x76, 0x00};
 static constexpr char default_comppack_url[] = {0};
+static constexpr char default_install_psp_game_path[] = "pspemu/PSP/GAME";
+static constexpr char default_install_psp_iso_path[] =  "pspemu/ISO";
 
 static char* skipnonws(char* text, char* end)
 {
@@ -174,7 +176,11 @@ Config pkgi_load_config()
         config.sort = SortByName;
         config.order = SortAscending;
         config.filter = DbFilterAll;
-        config.install_psp_psx_location = "ux0:";
+        config.install_psv_location = "ux0:";
+        config.install_psp_psx_location = config.install_psv_location;
+        config.install_psp_game_path = default_install_psp_game_path;
+        config.install_psp_iso_path = default_install_psp_iso_path;
+        config.install_psp_psx_path = default_install_psp_game_path;
 
         auto const path =
                 fmt::format("{}/config.txt", pkgi_get_config_folder());
@@ -245,6 +251,12 @@ Config pkgi_load_config()
                 config.install_psp_as_pbp = 1;
             else if (pkgi_stricmp(key, "install_psp_psx_location") == 0)
                 config.install_psp_psx_location = value;
+            else if (pkgi_stricmp(key, "install_psp_game_path") == 0)
+                config.install_psp_game_path = value;
+            else if (pkgi_stricmp(key, "install_psp_iso_path") == 0)
+                config.install_psp_iso_path = value;
+            else if (pkgi_stricmp(key, "install_psp_psx_path") == 0)
+                config.install_psp_psx_path = value;
         }
         return config;
     }
@@ -305,13 +317,16 @@ void pkgi_save_config(const Config& config)
     SAVE_CONF("url_psp_games", psp_games_url, default_psp_games_url)
     SAVE_CONF("url_psp_dlcs", psp_dlcs_url, default_psp_dlcs_url)
     SAVE_CONF("url_comppack", comppack_url, default_comppack_url)
-#undef SAVE_CONF
     if (!config.install_psp_psx_location.empty())
         len += pkgi_snprintf(
                 data + len,
                 sizeof(data) - len,
                 "install_psp_psx_location %s\n",
                 config.install_psp_psx_location.c_str());
+    SAVE_CONF("install_psp_game_path", install_psp_game_path, default_install_psp_game_path);
+    SAVE_CONF("install_psp_iso_path", install_psp_iso_path, default_install_psp_iso_path);
+    SAVE_CONF("install_psp_psx_path", install_psp_psx_path, default_install_psp_game_path);
+#undef SAVE_CONF
     len += pkgi_snprintf(
             data + len, sizeof(data) - len, "sort %s\n", sort_str(config.sort));
     len += pkgi_snprintf(

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -11,7 +11,11 @@ typedef struct Config
     uint32_t filter;
     int no_version_check;
     int install_psp_as_pbp;
+    std::string install_psv_location;
     std::string install_psp_psx_location;
+    std::string install_psp_game_path;
+    std::string install_psp_iso_path;
+    std::string install_psp_psx_path;
 
     std::string games_url;
     std::string dlcs_url;

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -387,6 +387,7 @@ void TitleDatabase::reload(
         uint32_t region_filter,
         DbSort sort_by,
         DbSortOrder sort_order,
+        const std::string& partition,
         const std::string& search,
         const std::set<std::string>& installed_games)
 {
@@ -474,6 +475,7 @@ void TitleDatabase::reload(
                 installed_games.find(titleid) != installed_games.end())
                 db.push_back(DbItem{
                         PresenceUnknown,
+                        partition,
                         titleid,
                         content,
                         0,

--- a/src/db.hpp
+++ b/src/db.hpp
@@ -52,6 +52,7 @@ enum DbFilter
 struct DbItem
 {
     DbPresence presence;
+    std::string partition;
     std::string titleid;
     std::string content;
     uint32_t flags;
@@ -102,6 +103,7 @@ public:
             uint32_t region_filter,
             DbSort sort_by,
             DbSortOrder sort_order,
+            const std::string& partition,
             const std::string& search,
             const std::set<std::string>& installed_games);
 

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -172,26 +172,26 @@ void Downloader::do_download_package(const DownloadItem& item)
     {
     case Game:
     case Dlc:
-        pkgi_install(item.content.c_str());
+        pkgi_install(item.partition.c_str(), item.content.c_str());
         break;
     case Patch:
-        pkgi_install_update(item.content.c_str());
+        pkgi_install_update(item.partition.c_str(), item.content.c_str());
         break;
     case PspGame:
         if (item.save_as_iso)
             pkgi_install_pspgame_as_iso(
-                    item.partition.c_str(), item.content.c_str());
+                    item.partition.c_str(), item.game_path.c_str(), item.iso_path.c_str(), item.content.c_str());
         else
-            pkgi_install_pspgame(item.partition.c_str(), item.content.c_str());
+            pkgi_install_pspgame(item.partition.c_str(), item.game_path.c_str(), item.content.c_str());
         break;
     case PspDlc:
-        pkgi_install_pspdlc(item.partition.c_str(), item.content.c_str());
+        pkgi_install_pspdlc(item.partition.c_str(), item.game_path.c_str(), item.content.c_str());
         break;
     case PsmGame:
-        pkgi_install_psmgame(item.content.c_str());
+        pkgi_install_psmgame(item.partition.c_str(), item.content.c_str());
         break;
     case PsxGame:
-        pkgi_install_pspgame(item.partition.c_str(), item.content.c_str());
+        pkgi_install_pspgame(item.partition.c_str(), item.psx_path.c_str(), item.content.c_str());
         break;
     case CompPackBase:
     case CompPackPatch:
@@ -227,7 +227,7 @@ void Downloader::do_download_comppack(const DownloadItem& item)
             item.partition.c_str(), item.content.c_str(), item.url.c_str());
     LOGF("download of comppack {} completed!", item.url);
     pkgi_install_comppack(
-            item.content, item.type == CompPackPatch, item.version);
+            item.partition, item.content, item.type == CompPackPatch, item.version);
     pkgi_rm(fmt::format("{}pkgj/{}-comp.ppk", item.partition, item.content)
                     .c_str());
     LOG("install of %s completed!", item.name.c_str());

--- a/src/downloader.hpp
+++ b/src/downloader.hpp
@@ -32,6 +32,9 @@ struct DownloadItem
     std::vector<uint8_t> digest;
     bool save_as_iso;
     std::string partition;
+    std::string game_path;
+    std::string iso_path;
+    std::string psx_path;
     // only used by compatibility packs
     std::string version;
 };

--- a/src/gameview.cpp
+++ b/src/gameview.cpp
@@ -253,8 +253,8 @@ void GameView::refresh()
     LOGF("refreshing gameview");
     _refood_present = pkgi_is_module_present("ref00d");
     _0syscall6_present = pkgi_is_module_present("0syscall6");
-    _game_version = pkgi_get_game_version(_item->titleid);
-    _comppack_versions = pkgi_get_comppack_versions(_item->titleid);
+    _game_version = pkgi_get_game_version(_item->partition, _item->titleid);
+    _comppack_versions = pkgi_get_comppack_versions(_item->partition, _item->titleid);
 }
 
 void GameView::start_download_package()
@@ -288,7 +288,10 @@ void GameView::start_download_comppack(bool patch)
                                   std::vector<uint8_t>{},
                                   std::vector<uint8_t>{},
                                   false,
-                                  "ux0:",
+                                  _config->install_psv_location,
+                                  _config->install_psp_game_path,
+                                  _config->install_psp_iso_path,
+                                  _config->install_psp_psx_path,
                                   entry->app_version});
 }
 

--- a/src/imagefetcher.cpp
+++ b/src/imagefetcher.cpp
@@ -56,12 +56,13 @@ std::string get_image_url(DbItem* item)
 
 ImageFetcher::ImageFetcher(DbItem* item)
     : _mutex("image_fetcher_mutex")
-    , _path(fmt::format("ux0:pkgj/cover/{}.jpg", item->titleid))
+    , _path(fmt::format("{}pkgj/cover/{}.jpg", item->partition, item->titleid))
     , _url(get_image_url(item))
     , _texture(nullptr)
     , _thread("image_fetcher", [this] { do_request(); })
 {
-    pkgi_mkdirs("ux0:pkgj/cover");
+    auto path = fmt::format("{}pkgj/cover", item->partition);
+    pkgi_mkdirs(path.c_str());
 }
 
 ImageFetcher::~ImageFetcher()

--- a/src/install.hpp
+++ b/src/install.hpp
@@ -10,19 +10,19 @@ struct CompPackVersion
     std::string patch;
 };
 
-std::vector<std::string> pkgi_get_installed_games();
-std::vector<std::string> pkgi_get_installed_themes();
-std::string pkgi_get_game_version(const std::string& titleid);
-CompPackVersion pkgi_get_comppack_versions(const std::string& titleid);
-bool pkgi_dlc_is_installed(const char* content);
-bool pkgi_psm_is_installed(const char* titleid);
-bool pkgi_psp_is_installed(const char* psppartition, const char* content);
-bool pkgi_psx_is_installed(const char* psppartition, const char* content);
-void pkgi_install(const char* contentid);
-void pkgi_install_update(const std::string& titleid);
+std::vector<std::string> pkgi_get_installed_games(const std::string& partition);
+std::vector<std::string> pkgi_get_installed_themes(const std::string& partition);
+std::string pkgi_get_game_version(const std::string& partition, const std::string& titleid);
+CompPackVersion pkgi_get_comppack_versions(const std::string& partition, const std::string& titleid);
+bool pkgi_dlc_is_installed(const char* partition, const char* content);
+bool pkgi_psm_is_installed(const char* partition, const char* titleid);
+bool pkgi_psp_is_installed(const char* psppartition, const char* gpath, const char* ipath, const char* content);
+bool pkgi_psx_is_installed(const char* psppartition, const char* ppath, const char* content);
+void pkgi_install(const char* partition, const char* contentid);
+void pkgi_install_update(const std::string& partition, const std::string& titleid);
 void pkgi_install_comppack(
-        const std::string& titleid, bool patch, const std::string& version);
-void pkgi_install_psmgame(const char* contentid);
-void pkgi_install_pspgame(const char* partition, const char* contentid);
-void pkgi_install_pspgame_as_iso(const char* partition, const char* contentid);
-void pkgi_install_pspdlc(const char* partition, const char* contentid);
+        const std::string& partition, const std::string& titleid, bool patch, const std::string& version);
+void pkgi_install_psmgame(const char* partition, const char* contentid);
+void pkgi_install_pspgame(const char* partition, const char* gpath, const char* contentid);
+void pkgi_install_pspgame_as_iso(const char* partition, const char* gpath, const char* ipath, const char* contentid);
+void pkgi_install_pspdlc(const char* partition, const char* gpath, const char* contentid);

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -140,6 +140,7 @@ void configure_db(TitleDatabase* db, const char* search, const Config* config)
                         : config->filter & ~DbFilterInstalled,
                 config->sort,
                 config->order,
+                config->install_psv_location,
                 search ? search : "",
                 installed_games);
     }
@@ -253,18 +254,18 @@ const char* pkgi_get_mode_partition()
         || mode == ModePspDlcs
         || mode == ModePsxGames
     ? config.install_psp_psx_location.c_str()
-    : "ux0:";
+    : config.install_psv_location.c_str();
 }
 
 void pkgi_refresh_installed_packages()
 {
-    auto games = pkgi_get_installed_games();
+    auto games = pkgi_get_installed_games(config.install_psv_location);
     installed_games.clear();
     installed_games.insert(
             std::make_move_iterator(games.begin()),
             std::make_move_iterator(games.end()));
 
-    auto themes = pkgi_get_installed_themes();
+    auto themes = pkgi_get_installed_themes(config.install_psv_location);
     installed_themes.clear();
     installed_themes.insert(
             std::make_move_iterator(themes.begin()),
@@ -457,28 +458,28 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
                     item->presence = PresenceInstalling;
                 break;
             case ModePsmGames:
-                if (pkgi_psm_is_installed(titleid))
+                if (pkgi_psm_is_installed(pkgi_get_mode_partition(), titleid))
                     item->presence = PresenceInstalled;
                 else if (downloader.is_in_queue(PsmGame, item->content))
                     item->presence = PresenceInstalling;
                 break;
             case ModePspDlcs:
                 if (pkgi_psp_is_installed(
-                            pkgi_get_mode_partition(), item->content.c_str()))
+                            pkgi_get_mode_partition(), config.install_psp_game_path.c_str(), config.install_psp_iso_path.c_str(), item->content.c_str()))
                     item->presence = PresenceGamePresent;
                 else if (downloader.is_in_queue(PspGame, item->content))
                     item->presence = PresenceInstalling;
                 break;
             case ModePspGames:
                 if (pkgi_psp_is_installed(
-                            pkgi_get_mode_partition(), item->content.c_str()))
+                            pkgi_get_mode_partition(), config.install_psp_game_path.c_str(), config.install_psp_iso_path.c_str(), item->content.c_str()))
                     item->presence = PresenceInstalled;
                 else if (downloader.is_in_queue(PspGame, item->content))
                     item->presence = PresenceInstalling;
                 break;
             case ModePsxGames:
                 if (pkgi_psx_is_installed(
-                            pkgi_get_mode_partition(), item->content.c_str()))
+                            pkgi_get_mode_partition(), config.install_psp_psx_path.c_str(), item->content.c_str()))
                     item->presence = PresenceInstalled;
                 else if (downloader.is_in_queue(PsxGame, item->content))
                     item->presence = PresenceInstalling;
@@ -486,7 +487,7 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
             case ModeDlcs:
                 if (downloader.is_in_queue(Dlc, item->content))
                     item->presence = PresenceInstalling;
-                else if (pkgi_dlc_is_installed(item->content.c_str()))
+                else if (pkgi_dlc_is_installed(item->partition.c_str(), item->content.c_str()))
                     item->presence = PresenceInstalled;
                 else if (pkgi_is_installed(titleid))
                     item->presence = PresenceGamePresent;
@@ -865,20 +866,11 @@ void pkgi_do_tail(Downloader& downloader)
     }
     pkgi_draw_text(0, second_line, PKGI_COLOR_TEXT_TAIL, text);
 
-    // get free space of partition only if looking at psx or psp games else show
-    // ux0:
     char size[64];
-    if (mode == ModePsxGames || mode == ModePspGames)
-    {
-        pkgi_friendly_size(
+    pkgi_friendly_size(
                 size,
                 sizeof(size),
                 pkgi_get_free_space(pkgi_get_mode_partition()));
-    }
-    else
-    {
-        pkgi_friendly_size(size, sizeof(size), pkgi_get_free_space("ux0:"));
-    }
 
     char free[64];
     pkgi_snprintf(free, sizeof(free), "Free: %s", size);
@@ -1025,6 +1017,7 @@ void pkgi_start_download(Downloader& downloader, const DbItem& item)
             {
                 pkgi_start_bgdl(
                         mode_to_bgdl_type(mode),
+                        item.partition,
                         item.name,
                         item.url,
                         item.zrif.empty()
@@ -1053,6 +1046,9 @@ void pkgi_start_download(Downloader& downloader, const DbItem& item)
                                         : std::vector<uint8_t>{},
                         !config.install_psp_as_pbp,
                         pkgi_get_mode_partition(),
+                        config.install_psp_game_path,
+                        config.install_psp_iso_path,
+                        config.install_psp_psx_path,
                         ""});
         }
         else


### PR DESCRIPTION
Make the PSP install path (for eboot, ISO and PSX) configurable. This enables support for plugins like gclite (just modify the configuration to include the category folder). The newly added configuration is treated as optional and will not be written unless set.

As a side-effect of altering this, make the vita partition configurable so it has parity in the codebase.

Addresses #339