### PR TITLE
Enable search to find hits for titleid in addition to name

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -453,7 +453,8 @@ void TitleDatabase::reload(
                 continue;
 
             if (!search.empty() &&
-                !pkgi_stricontains(name.c_str(), search.c_str()))
+                !pkgi_stricontains(name.c_str(), search.c_str()) &&
+                !pkgi_stricontains(titleid.c_str(), search.c_str()))
                 continue;
 
             bool bdigest = true;


### PR DESCRIPTION
I wanted a feature to be able to find all the DLC for a specific game, and I can see I'm not the only one ([1](https://github.com/blastrock/pkgj/issues/343), [2](https://github.com/blastrock/pkgj/issues/361), [3](https://github.com/blastrock/pkgj/issues/376)). Without spending a ton of time getting to know the ins and outs of the source, this was the simplest way I could come up with to accomplish that. This PR enables search to find hits for `titleid` in addition to `name`, so searching for a game's `titleid` in the DLC-view will pull up all DLC items for the game in question.