### PR TITLE
Reapply search filter when refreshing database or changing modes

### DIFF
--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -234,7 +234,7 @@ void pkgi_refresh_thread(void)
         }
         first_item = 0;
         selected_item = 0;
-        configure_db(db.get(), NULL, &config);
+        configure_db(db.get(), search_active ? search_text : NULL, &config);
     }
     catch (const std::exception& e)
     {
@@ -964,7 +964,7 @@ void pkgi_reload()
 {
     try
     {
-        configure_db(db.get(), NULL, &config);
+        configure_db(db.get(), search_active ? search_text : NULL, &config);
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
This has been bothering me for some time.
When trying to find games of a specific franchise, regardless of platform, You'd apply a search filter and then switch between Vita, PSP, and PSX modes to see what's available.
However, in current upstream the search filter is not reapplied when switching modes. This PR fixes that.

P.S.: There seem to be an issue with the bzip2 conan dependecy because bitcrafters [shut down](https://bincrafters.github.io/2020/04/19/infrastructure-changes-and-required-actions/). If you have trouble compiling, check out [this commit](https://github.com/knoellle/pkgj/commit/c7766831cf7b72f5133e0719813f45e93e837a13). It might be hacky as I have little experience with conan, but it worked for me to compile the project.