### PR TITLE
feat: DLC multi-select, PSP gameview, annotations, CI pipeline fixes,…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,161 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]*.[0-9]*'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+# Restrict default token permissions; the release job overrides with contents: write.
+permissions:
+  contents: read
+
+jobs:
+  # ── PS Vita build ────────────────────────────────────────────────────────────
+  build-vita:
+    name: Build PS Vita (pkgj.vpk)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: sudo apt-get install -y ninja-build g++-12
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: pip install 'poetry<2.0'
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2/p
+          key: conan-vita-${{ runner.os }}-${{ hashFiles('ci/conan-vitasdk/conanfile.py', 'ci/conan-fmt/conanfile.py', 'ci/conan-libzip/conanfile.py', 'ci/conan-vitasqlite/conanfile.py', 'conanfile.py') }}
+          restore-keys: conan-vita-${{ runner.os }}-
+
+      - name: Build pkgj.vpk
+        env:
+          CC: gcc-12
+          CXX: g++-12
+        run: |
+          cd ci
+          ./setup_conan.sh
+          mkdir -p build && cd build
+          poetry run conan install ../.. \
+            --build missing \
+            -s build_type=RelWithDebInfo \
+            --profile:host vita \
+            --output-folder .
+          poetry run conan build ../.. \
+            -s build_type=RelWithDebInfo \
+            --profile:host vita \
+            --output-folder .
+
+      - name: Upload pkgj.vpk
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgj-vita
+          path: ci/build/pkgj.vpk
+          if-no-files-found: error
+
+  # ── Host build (CLI + graphical simulator) ───────────────────────────────────
+  build-host:
+    name: Build Host (pkgj_cli + pkgj_sim)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ninja-build g++-12 pkg-config \
+            libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+            libcurl4-openssl-dev
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: pip install 'poetry<2.0'
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2/p
+          key: conan-host-${{ runner.os }}-${{ hashFiles('ci/conan-fmt/conanfile.py', 'ci/conan-libzip/conanfile.py', 'conanfile.py') }}
+          restore-keys: conan-host-${{ runner.os }}-
+
+      - name: Build pkgj_cli and pkgj_sim
+        env:
+          CC: gcc-12
+          CXX: g++-12
+        run: |
+          cd ci
+          ./setup_conan.sh
+          mkdir -p buildhost && cd buildhost
+          poetry run conan install ../.. \
+            --build missing \
+            -s build_type=RelWithDebInfo \
+            -s compiler=gcc \
+            -s compiler.version=12 \
+            -s compiler.libcxx=libstdc++11 \
+            --output-folder .
+          cmake ../.. \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DHOST_BUILD=ON \
+            -DBUILD_SIM=ON \
+            -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake
+          ninja pkgj_cli pkgj_sim
+
+      - name: Upload pkgj_cli
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgj-cli
+          path: ci/buildhost/pkgj_cli
+          if-no-files-found: error
+
+      - name: Upload pkgj_sim
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkgj-sim
+          path: ci/buildhost/pkgj_sim
+          if-no-files-found: error
+
+  # ── GitHub Release ────────────────────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-24.04
+    needs: [build-vita, build-host]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4.1.3
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "$TAG" == *"beta"* || "$TAG" == *"alpha"* || "$TAG" == *"rc"* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --generate-notes \
+            $PRERELEASE_FLAG \
+            "pkgj-vita/pkgj.vpk#pkgj-${TAG}.vpk" \
+            "pkgj-cli/pkgj_cli#pkgj_cli-${TAG}" \
+            "pkgj-sim/pkgj_sim#pkgj_sim-${TAG}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 /build*
+!/build.sh
 /ci/build*
 /ci/conan-*/test_package*/build
 /.vscode
 .tags
 CMakeUserPresets.json
 TODO
+send_to_vita.sh
+send_to_ubuntu.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,95 @@
 # Changelog
 
+
+## 0.59-beta2
+
+### New features
+
+- **Linux simulator** (`pkgj_sim`): Full SDL2 + ImGui graphical simulator for development on Linux.
+  Keyboard maps all Vita buttons; overlays (config editor, log viewer) work identically to the Vita build.
+  Build with `./build.sh host` or `-DBUILD_SIM=ON` in CMake.
+
+### Note
+
+- Skipped version 0.59 full to avoid conflicts with releases from other contributors (those may be merged in the future).
+
+
+- **Log levels**: Every log entry is now tagged `[INFO]`, `[WARN]`, or `[ERR ]`.
+  The Log Viewer colors rows by level — red for errors, yellow for warnings, white for info.
+  New macros: `LOG_WARN`, `LOG_ERR`, `LOGFW`, `LOGFE` for explicit leveling.
+
+- **Log timestamps**: All log lines carry a `HH:MM:SS` prefix.
+
+- **Log module names**: Each log line shows the source file stem, e.g. `[downloader]`, `[pkgi]`.
+
+### Improvements
+
+- Cover image panel proportions corrected: width 1.5× original, height 70% of that, top-aligned.
+- All log messages across 17+ source files rewritten for clarity and consistency.
+- Critical failure paths (download error, DB failure, OS primitive failures, PKG integrity, install errors) now emit `[ERR ]`-level entries; recoverable conditions emit `[WARN]`.
+
+### Bug fixes
+
+- Fixed input hold-repeat broken by over-aggressive button state zeroing (`.down` is now preserved across overlay open/close).
+- Fixed Log Viewer not closing with Esc in simulator mode.
+- Fixed Config Editor and Log Viewer invisible in simulator (over-aggressive `#ifndef PKGI_SIMULATOR` guards removed).
+- Fixed `has_imgui_overlay` not including the Config Editor in simulator mode.- Fixed race / deadlock during rapid GameView open/close by refactoring `ImageFetcher` to share a single global worker slot (`WorkerSlot::image_worker()`), avoid per-instance blocking joins, and prevent duplicate concurrent downloads.- Fixed Log Viewer navigation to use `input.active` (same repeat rate as the main game list).
+
+
+## 0.59-beta1
+
+
+What's new:
+
+- Added a PSP game details view with cover art, metadata, diagnostics, and personal notes.
+- Added explicit PSP install actions in game view: install as ISO, plus queue as PBP in LiveArea when NoPspEmuDrm is available.
+- Moved the PSP ISO/PBP choice out of `config.txt` and into the PSP game view.
+- Unified cover loading around `ImageFetcher` and removed the separate thumbnail fetcher path.
+- Improved cover presentation with larger portrait-oriented panels and PSP game view support.
+- Added clearer cover loading states: download in progress and final download error.
+
+Bug fixes:
+
+- Fixed rapid game view open/close crashes caused by unsafe cover texture lifetime handling.
+- Fixed stale square cover cache reuse when switching to the newer default cover path.
+- Fixed decimal size formatting to use consistent base-10 units across the UI.
+- Fixed PSP game view to avoid Vita-only patch checks and compatibility pack logic.
+
+
+## 0.57
+
+What's new:
+
+    Added BGDL for PSM Games- you will need to update NoPsmDrm to v1.5 for this to work
+    If PSM Runtime is not installed and you try download a PSM game, it will be downloaded also
+    Fixed "failed to rename: 0x80010016" error that sometimes happened when downloading PSX/PSP games.
+
+## 0.56
+
+What's new:
+
+    added Background Download of PSP games using (note: this requires the NoPspEmuDrm plugin to be installed to use)
+    added INT region .
+    added option to re download games you already have installed
+    fixed game install location for PSX games
+
+If you do not have NoPspEmuDrm the old downloader will be used instead and wont create bubbles on livearea
+
+## 0.56-beta4
+
+What's new:
+
+    Added ability to redownload games you already have installed
+    Fix PSX Games installed to the live area not showing up as installed
+    Fix ??? Regions on some PSP and PSX games
+
+
+## 0.56-beta3 
+
+What's new:
+
+    Download PSP games from Live Area (credits to @LiEnby)
+
 ## 0.55
 
 What's new:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(VITA_APP_NAME "PKGj+" CACHE STRING "Vita application display name")
 set(VITA_TITLEID  "PKGJ00001" CACHE STRING "Vita Title ID (4 letters + 5 digits)")
-set(VITA_VERSION  "0.60" CACHE STRING "Vita application version (XX.XX format for param.sfo)")
+set(VITA_VERSION  "0.61" CACHE STRING "Vita application version (XX.XX format for param.sfo)")
 set(PKGI_DISPLAY_VERSION "0.61" CACHE STRING "Version string shown in the app header")
 
 option(PKGI_ENABLE_LOGGING "enables debug logging over udp multicast" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,10 @@ endif()
 # useful for memory alignment constraints
 set(CMAKE_CXX_STANDARD 17)
 
-set(VITA_APP_NAME "PKGj")
-set(VITA_TITLEID  "PKGJ00000")
-set(VITA_VERSION  "0.58")
+set(VITA_APP_NAME "PKGj+" CACHE STRING "Vita application display name")
+set(VITA_TITLEID  "PKGJ00001" CACHE STRING "Vita Title ID (4 letters + 5 digits)")
+set(VITA_VERSION  "0.60" CACHE STRING "Vita application version (XX.XX format for param.sfo)")
+set(PKGI_DISPLAY_VERSION "0.60-beta1" CACHE STRING "Version string shown in the app header")
 
 option(PKGI_ENABLE_LOGGING "enables debug logging over udp multicast" OFF)
 
@@ -23,7 +24,7 @@ if(PKGI_ENABLE_LOGGING)
   add_definitions(-DPKGI_ENABLE_LOGGING)
 endif()
 
-add_definitions(-DPKGI_VERSION="${VITA_VERSION}" -D_GNU_SOURCE)
+add_definitions(-DPKGI_VERSION="${PKGI_DISPLAY_VERSION}" -D_GNU_SOURCE)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -fvisibility=hidden")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fvisibility=hidden")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(VITA_APP_NAME "PKGj+" CACHE STRING "Vita application display name")
 set(VITA_TITLEID  "PKGJ00001" CACHE STRING "Vita Title ID (4 letters + 5 digits)")
 set(VITA_VERSION  "0.60" CACHE STRING "Vita application version (XX.XX format for param.sfo)")
-set(PKGI_DISPLAY_VERSION "0.60-beta1" CACHE STRING "Version string shown in the app header")
+set(PKGI_DISPLAY_VERSION "0.61" CACHE STRING "Version string shown in the app header")
 
 option(PKGI_ENABLE_LOGGING "enables debug logging over udp multicast" OFF)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,312 @@
+# PKGj — Developer Guide (toaster-code/pkgj fork)
+
+This document covers: what changed in this fork, how to build, how to test via the CLI simulator, and how to generate the final Vita binary (`.vpk`).
+
+---
+
+## Table of Contents
+
+1. [What was changed and why](#1-what-was-changed-and-why)
+2. [New feature: Personal Annotations & Flags](#2-new-feature-personal-annotations--flags)
+3. [How to build (CLI / host simulator)](#3-how-to-build-cli--host-simulator)
+4. [Testing with the CLI simulator](#4-testing-with-the-cli-simulator)
+5. [How to generate the Vita binary](#5-how-to-generate-the-vita-binary)
+6. [File change summary](#6-file-change-summary)
+
+---
+
+## 1. What was changed and why
+
+This fork extends the original [blastrock/pkgj](https://github.com/blastrock/pkgj) with a **personal annotation system** that lets users attach a personal flag (e.g. "Broken", "Favorite", "Completed") and a free-text comment to any title in the list — directly from the GameView — without modifying any existing database.
+
+The original application had no way to track personal notes about a game. The change adds this capability in a **non-breaking** way: a new SQLite file is created alongside the existing databases, and all existing data is untouched.
+
+---
+
+## 2. New feature: Personal Annotations & Flags
+
+### What it does
+
+- In the **title list**, any item with a flag set shows a short ASCII symbol prefix next to the name:
+
+  | Symbol | Meaning       |
+  |--------|---------------|
+  | `[*]`  | Favorite      |
+  | `[++]` | Very Good     |
+  | `[+]`  | Good          |
+  | `[-]`  | Bad           |
+  | `[--]` | Very Bad      |
+  | `[X]`  | Broken        |
+  | `[/]`  | Completed     |
+  | `[?]`  | Want to Play  |
+
+- In the **GameView** (opened by pressing O/X on a game), a new **"Personal Notes"** section appears at the bottom of the window with:
+  - **Flag picker** — one button per flag value; the active one is highlighted in green.
+  - **Comment field** — multi-line free-text input.
+  - **Save Notes** button — writes flag + comment to the database, immediately updates the list row.
+  - **Clear Notes** button — removes the annotation entirely.
+
+### Where data is stored
+
+Annotations are stored in:
+```
+ux0:data/pkgj/annotations.db       (on Vita)
+<configFolder>/annotations.db      (in simulator)
+```
+
+This is a standard SQLite3 file with one table:
+```sql
+CREATE TABLE annotations (
+    titleid TEXT PRIMARY KEY NOT NULL,
+    flag    INTEGER NOT NULL DEFAULT 0,
+    comment TEXT    NOT NULL DEFAULT ''
+);
+```
+
+Annotations survive database refreshes and app restarts. The file is created automatically on first launch.
+
+---
+
+## 3. How to build (CLI / host simulator)
+
+### Prerequisites
+
+- Linux (Debian/Ubuntu recommended)
+- `gcc-12` and `g++-12`
+- Python 3.6+ with [Poetry](https://python-poetry.org/)
+- Internet access (Conan downloads dependencies on first build)
+
+### Steps
+
+```bash
+# 1. Enter the ci/ directory
+cd /path/to/pkgj/ci
+
+# 2. Install Conan via Poetry and configure profiles (first time only)
+./setup_conan.sh
+
+# 3. Install host dependencies
+export CC=gcc-12 CXX=g++-12
+mkdir buildhost
+poetry run conan install .. \
+  --build missing \
+  -s build_type=RelWithDebInfo \
+  -s compiler=gcc \
+  -s compiler.version=12 \
+  -s compiler.libcxx=libstdc++11 \
+  --output-folder buildhost
+
+# 4. Compile
+poetry run conan build .. \
+  -s build_type=RelWithDebInfo \
+  -s compiler=gcc \
+  -s compiler.version=12 \
+  -s compiler.libcxx=libstdc++11 \
+  --output-folder buildhost
+```
+
+The resulting binary is at `ci/buildhost/pkgj_cli`.
+
+> **Note:** Steps 3 and 4 also configure and build via CMake internally. After the first build, you can rebuild faster using:
+> ```bash
+> cd ci/buildhost && source conanbuild.sh && cmake --build . --target pkgj_cli
+> ```
+
+---
+
+## 4. Testing with the CLI simulator
+
+The `pkgj_cli` binary uses `simulator.cpp` to replace all Vita-specific syscalls (file I/O, memory, time) with standard POSIX equivalents, allowing the database, download, and extraction logic to be tested on a regular Linux machine.
+
+> **Important:** `FileHttp` in the simulator reads **local files**, not real HTTP URLs. To test with online data, download the file first with `curl` and pass the local path.
+
+### Available subcommands
+
+```
+pkgj_cli refreshlist    <MODE> <tsv_file>
+pkgj_cli filedownload   <local_file_or_url>
+pkgj_cli extractzip     <zip_file>
+pkgj_cli refreshcomppack <local_file>
+pkgj_cli extract        <pkg_file> <zrif> <sha256>
+pkgj_cli patchinfo      <xml_file> <titleid>
+```
+
+---
+
+### Test 1 — Parse a real TSV database
+
+Download the community PSVita game list and parse it:
+
+```bash
+cd ci/buildhost
+
+# Download the TSV
+curl -L "https://raw.githubusercontent.com/txy7795679/PSVITA-PKGJ-DATADB/refs/heads/master/PSV_GAMES.tsv" \
+     -o PSV_GAMES.tsv
+
+# Parse and display titles sorted by size
+./pkgj_cli refreshlist PSVGAMES PSV_GAMES.tsv | head -20
+```
+
+Expected output (titles sorted descending by file size):
+```
+The Lost Child (3.61+!) [3.65]: 3537465536
+The Sly Trilogy: 3526375296
+...
+Persona 4: The Golden (PlayStation Vita the Best): 3335541664
+```
+
+---
+
+### Test 2 — Extract a zip (compatibility pack simulation)
+
+The `extractzip` command simulates how PKGj extracts compatibility packs on the Vita. It extracts to `./tmp/`.
+
+Create a test zip (Python, since `zip` may not be installed):
+
+```bash
+cd ci/buildhost
+
+python3 - <<'EOF'
+import zipfile
+with zipfile.ZipFile('test_pack.zip', 'w', zipfile.ZIP_DEFLATED) as z:
+    # Directory entries must come before their files (required by extractzip)
+    z.mkdir('sce_sys')
+    z.writestr('sce_sys/param.sfo', b'\x00PSF' + b'fake PARAM.SFO data')
+    z.writestr('eboot.bin', b'fake eboot.bin data')
+    z.writestr('data.bin', b'fake comppack data')
+print("Created test_pack.zip")
+EOF
+
+mkdir -p tmp
+./pkgj_cli extractzip test_pack.zip
+find tmp/ -type f
+```
+
+Expected output:
+```
+tmp/eboot.bin
+tmp/sce_sys/param.sfo
+tmp/data.bin
+```
+
+> **Note:** `extractzip` requires that **directory entries** (names ending in `/`) appear in the zip before the files inside them. When creating zips programmatically, use `z.mkdir()` or add an explicit `ZipInfo` entry for each directory.
+
+---
+
+### Test 3 — File download simulation
+
+```bash
+# Simulate downloading a local file (FileHttp reads local paths as if they were URLs)
+./pkgj_cli filedownload PSV_GAMES.tsv
+# Output written to ./tmp/
+```
+
+---
+
+## 5. How to generate the Vita binary
+
+### Additional prerequisites
+
+- [VitaSDK](https://vitasdk.org/) installed — see install steps below
+- VitaSDK in PATH: `export VITASDK=~/vitasdk && export PATH=$VITASDK/bin:$PATH`
+
+### Install VitaSDK (if not present)
+
+Without this the Vita build will fail immediately with `arm-vita-eabi-gcc: command not found`.
+
+`bootstrap-vitasdk.sh` installs to the path in `$VITASDK`. If that variable is unset, it defaults to `/usr/local/vitasdk` (requires `sudo`). To install without root, point it somewhere in your home directory first:
+
+```bash
+# Option A — system-wide (requires sudo, installs to /usr/local/vitasdk)
+git clone https://github.com/vitasdk/vdpm /tmp/vdpm
+cd /tmp/vdpm
+sudo ./bootstrap-vitasdk.sh
+
+# Option B — user-local (no sudo, installs to ~/vitasdk)
+export VITASDK=~/vitasdk
+git clone https://github.com/vitasdk/vdpm /tmp/vdpm
+cd /tmp/vdpm
+./bootstrap-vitasdk.sh
+```
+
+After installation, add this to `~/.bashrc` (adjust path if you used Option B):
+
+```bash
+export VITASDK=/usr/local/vitasdk   # or ~/vitasdk for Option B
+export PATH=$VITASDK/bin:$PATH
+```
+
+Verify:
+
+```bash
+arm-vita-eabi-gcc --version
+```
+
+### Build the VPK
+
+> ⚠️ **This will fail without VitaSDK installed.** Do not skip the prerequisite steps above.
+
+```bash
+cd /path/to/pkgj/ci
+
+export CC=gcc-12 CXX=g++-12
+
+# Run setup once if you haven't already (exports conan packages, copies vita profile)
+./setup_conan.sh
+
+mkdir build && cd build
+
+poetry run conan install ../.. \
+  --build missing \
+  -s build_type=RelWithDebInfo \
+  --profile:host vita \
+  --output-folder .
+
+poetry run conan build ../.. \
+  -s build_type=RelWithDebInfo \
+  --profile:host vita \
+  --output-folder .
+
+# Optional: copy the unsigned ELF (includes debug symbols)
+cp pkgj pkgj.elf
+```
+
+Output files in `ci/build/`:
+| File | Description |
+|------|-------------|
+| `eboot.bin` | Signed SELF — the actual executable loaded by the Vita |
+| `pkgj.vpk` | Full installable package (includes `eboot.bin` + Live Area assets) |
+| `pkgj.elf` | Unsigned ELF — useful for debugging with `gdb` or disassembly |
+
+### Install on Vita via FTP
+
+```bash
+# With VitaShell FTP running on the Vita at $PSVITAIP:1337
+curl -T ci/build/eboot.bin ftp://$PSVITAIP:1337/ux0:/app/PKGJ00000/
+```
+
+Or use the provided CMake target (builds and sends in one step):
+```bash
+cd ci/build
+PSVITAIP=192.168.1.x cmake --build . --target send
+```
+
+---
+
+## 6. File change summary
+
+| File | Type | Description |
+|------|------|-------------|
+| `src/annotationdb.hpp` | **New** | `UserFlag` enum, `UserAnnotation` struct, `AnnotationDatabase` class declaration |
+| `src/annotationdb.cpp` | **New** | SQLite CRUD: opens/creates `annotations.db`, implements `get()`, `set()`, `remove()` |
+| `src/db.hpp` | **Modified** | Added `#include "annotationdb.hpp"`; added `user_flag` and `user_comment` fields to `DbItem` struct |
+| `src/db.cpp` | **Modified** | Explicit initialization of new `DbItem` fields in `reload()` to silence compiler warnings |
+| `src/gameview.hpp` | **Modified** | Added `AnnotationDatabase*` to constructor; added private members `_annotationDb`, `_annotation`, `_comment_buf[512]`, `_annotation_dirty` |
+| `src/gameview.cpp` | **Modified** | Constructor loads saved annotation into working copy; new **Personal Notes** UI section in `render()` |
+| `src/pkgi.cpp` | **Modified** | Added `annotation_db` global; `pkgi_apply_annotations()` called after every `configure_db()`; flag symbol prefix in list draw loop; `annotation_db` passed to `GameView` constructor; forward declaration of `pkgi_apply_annotations()` added for strict compiler compatibility |
+| `src/workerpool.hpp` | **New** | Added single global worker slot abstraction; `try_submit(task_id, fn)` avoids duplicate/parallel fetch tasks |
+| `src/imagefetcher.hpp` | **Modified** | Reworked to use `WorkerSlot::image_worker()`, state machine via `_submitted`, `_result`, and `ImageFetchResult` instead of per-instance thread + mutex/abort |
+| `src/imagefetcher.cpp` | **Modified** | `ImageFetcher::_try_submit()` submits network+disk work to worker slot; `get_status()` and `get_texture()` process result asynchronously and safely on main thread |
+| `cross.cmake` | **Modified** | Added `src/annotationdb.cpp` to the Vita executable source list |
+| `host.cmake` | **Modified** | Added `src/annotationdb.cpp` to the `pkgj_cli` source list |

--- a/README.md
+++ b/README.md
@@ -156,8 +156,4 @@ puff.h and puff.c files are under [zlib][] license.
 [img_latest]: https://img.shields.io/github/release/blastrock/pkgj.svg?maxAge=3600
 [img_license]: https://img.shields.io/github/license/blastrock/pkgj.svg?maxAge=2592000
 
-# Donating
-
-Bitcoin: 128vikqd3AyNEXEiU5uSJvCrRq1e3kRX6n
-
-Monero: 45sCwEFcPD9ZfwD2UKt6gcG3vChFrMmJHUmVVBUWwPFoPsjmkzvN7i9DKn4pUkyif5axgbnYNqU3NCqugudjTWqdFv5uKQV
+:)

--- a/assets/sce_sys/livearea/contents/template.xml.in
+++ b/assets/sce_sys/livearea/contents/template.xml.in
@@ -20,7 +20,7 @@
 	<frame id="frame3">
 		<liveitem>
 			<text valign="top" align="left" text-align="left" text-valign="top" line-space="2" ellipsis="on">
-				<str size="22" shadow="on">by blastrock&#xD;&#xA;and cuevavirus</str>
+				<str size="22" shadow="on">by toaster-code&#xD;&#xA;(fork of blastrock)</str>
 			</text>
 		</liveitem>
 	</frame>

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 # build.sh — convenience build script for pkgj fork
 #
 # Usage:
-#   ./build.sh [target] [--clean]
+#   ./build.sh [target] [--clean] [--fake-version VERSION]
 #
 # Targets:
 #   host          Build host simulator   (output: ci/buildhost/pkgj_cli)
@@ -14,7 +14,12 @@
 #                   (Safe to install alongside the release build on the same Vita)
 #
 # Options:
-#   --clean   Remove the build directory before building (full rebuild)
+#   --clean              Remove the build directory before building (full rebuild)
+#   --fake-version VER   Override PKGI_VERSION with VER so the running app thinks it
+#                        is an older version and triggers the auto-update check.
+#                        Example: ./build.sh vita --fake-version 0.59
+#                        (install that VPK on the Vita, open PKGj+ → it should offer
+#                         to download the real latest release from GitHub)
 
 set -euo pipefail
 
@@ -23,18 +28,36 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 TARGET="vita"
 CLEAN=0
+FAKE_VERSION=""
 
-for arg in "$@"; do
-    case "$arg" in
-        host|vita|vita-release|vita-test) TARGET="$arg" ;;
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        host|vita|vita-release|vita-test) TARGET="$1" ;;
         --clean) CLEAN=1 ;;
+        --fake-version)
+            shift
+            FAKE_VERSION="${1:-}"
+            if [[ -z "$FAKE_VERSION" ]]; then
+                echo "--fake-version requires a version argument (e.g. 0.59)"
+                exit 1
+            fi
+            ;;
         *)
-            echo "Unknown argument: $arg"
-            echo "Usage: $0 [host|vita|vita-release|vita-test] [--clean]"
+            echo "Unknown argument: $1"
+            echo "Usage: $0 [host|vita|vita-release|vita-test] [--clean] [--fake-version VERSION]"
             exit 1
             ;;
     esac
+    shift
 done
+
+# Build the CMake -D flag for the fake version (empty string = use real version)
+VERSION_OVERRIDE=""
+if [[ -n "$FAKE_VERSION" ]]; then
+    # Override both the runtime version (PKGI_VERSION) and the param.sfo version (LiveArea)
+    VERSION_OVERRIDE="-DPKGI_DISPLAY_VERSION=${FAKE_VERSION} -DVITA_VERSION=${FAKE_VERSION}"
+    echo "==> Fake version mode: PKGI_VERSION + param.sfo APP_VER will be \"${FAKE_VERSION}\" (for update testing)"
+fi
 
 [[ "$TARGET" == "vita-release" ]] && TARGET="vita"
 
@@ -98,16 +121,33 @@ case "$TARGET" in
             --build missing \
             --output-folder .
 
-        poetry run conan build ../.. \
-            -s build_type=RelWithDebInfo \
-            --profile:host vita \
-            --output-folder .
+        if [[ -n "$FAKE_VERSION" ]]; then
+            # cmake directly so we can pass the version override at configure time
+            export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+            export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}"
+            [[ -f conanbuildenv-relwithdebinfo-armv7.sh ]] && \
+                source conanbuildenv-relwithdebinfo-armv7.sh
+
+            cmake ../.. \
+                -G Ninja \
+                -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake \
+                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                ${VERSION_OVERRIDE}
+
+            cmake --build .
+        else
+            poetry run conan build ../.. \
+                -s build_type=RelWithDebInfo \
+                --profile:host vita \
+                --output-folder .
+        fi
 
         # Keep ELF with debug symbols alongside the stripped eboot
         [[ -f pkgj ]] && cp pkgj pkgj.elf
 
         echo ""
         echo "==> Done.  Package: ci/build/pkgj.vpk"
+        [[ -n "$FAKE_VERSION" ]] && echo "    Built with fake version \"${FAKE_VERSION}\" — auto-update test build."
         ;;
 
     # ------------------------------------------------------------------
@@ -141,7 +181,8 @@ case "$TARGET" in
             -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DVITA_TITLEID="PKGJ00099" \
-            -DVITA_APP_NAME="PKGj+ TEST"
+            -DVITA_APP_NAME="PKGj+ TEST" \
+            ${VERSION_OVERRIDE:-}
 
         # Step 3: cmake build
         cmake --build .
@@ -151,5 +192,6 @@ case "$TARGET" in
         echo ""
         echo "==> Done.  Package: ci/buildtest/pkgj.vpk"
         echo "    Title ID PKGJ00099 — safe to install alongside the release build."
+        [[ -n "$FAKE_VERSION" ]] && echo "    Built with fake version \"${FAKE_VERSION}\" — auto-update test build."
         ;;
 esac

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# build.sh — convenience build script for pkgj fork
+#
+# Usage:
+#   ./build.sh [target] [--clean]
+#
+# Targets:
+#   host          Build host simulator   (output: ci/buildhost/pkgj_cli)
+#   vita          Build PS Vita release   (output: ci/build/pkgj.vpk)       [default]
+#   vita-release  Same as vita
+#   vita-test     Build PS Vita test      (output: ci/buildtest/pkgj.vpk)
+#                   Title ID : PKGJ00099
+#                   App name : "PKGj+ TEST"
+#                   (Safe to install alongside the release build on the same Vita)
+#
+# Options:
+#   --clean   Remove the build directory before building (full rebuild)
+
+set -euo pipefail
+
+# ── Resolve project root ──
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TARGET="vita"
+CLEAN=0
+
+for arg in "$@"; do
+    case "$arg" in
+        host|vita|vita-release|vita-test) TARGET="$arg" ;;
+        --clean) CLEAN=1 ;;
+        *)
+            echo "Unknown argument: $arg"
+            echo "Usage: $0 [host|vita|vita-release|vita-test] [--clean]"
+            exit 1
+            ;;
+    esac
+done
+
+[[ "$TARGET" == "vita-release" ]] && TARGET="vita"
+
+# ── Compilers ──
+export CC="${CC:-gcc-12}"
+export CXX="${CXX:-g++-12}"
+
+# ── VitaSDK ──
+export VITASDK="${VITASDK:-/root/vitasdk}"
+export PATH="$VITASDK/bin:$PATH"
+
+# ── Must run conan from inside ci/ so Poetry finds pyproject.toml ──
+cd "$SCRIPT_DIR/ci"
+
+# ── Helper: clean build dir ──
+maybe_clean() {
+    local dir="$1"
+    if [[ $CLEAN -eq 1 && -d "$dir" ]]; then
+        echo "==> Removing $dir"
+        rm -rf "$dir"
+    fi
+    mkdir -p "$dir"
+}
+
+# ── Build ──
+case "$TARGET" in
+
+    # ------------------------------------------------------------------
+    host)
+        echo "==> Building host simulator"
+        maybe_clean buildhost
+        cd buildhost
+
+        poetry run conan install ../.. \
+            -s build_type=RelWithDebInfo \
+            -s compiler=gcc \
+            -s compiler.version=12 \
+            -s compiler.libcxx=libstdc++11 \
+            --build missing \
+            --output-folder .
+
+        cmake ../.. \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DBUILD_SIM=ON
+
+        ninja pkgj_cli pkgj_sim
+
+        echo ""
+        echo "==> Done.  Binaries: ci/buildhost/pkgj_cli  ci/buildhost/pkgj_sim"
+        ;;
+
+    # ------------------------------------------------------------------
+    vita)
+        echo "==> Building Vita release  (PKGJ00001 / PKGj+)"
+        maybe_clean build
+        cd build
+
+        poetry run conan install ../.. \
+            -s build_type=RelWithDebInfo \
+            --profile:host vita \
+            --build missing \
+            --output-folder .
+
+        poetry run conan build ../.. \
+            -s build_type=RelWithDebInfo \
+            --profile:host vita \
+            --output-folder .
+
+        # Keep ELF with debug symbols alongside the stripped eboot
+        [[ -f pkgj ]] && cp pkgj pkgj.elf
+
+        echo ""
+        echo "==> Done.  Package: ci/build/pkgj.vpk"
+        ;;
+
+    # ------------------------------------------------------------------
+    vita-test)
+        echo "==> Building Vita TEST  (PKGJ00099 / PKGj+ TEST)"
+        maybe_clean buildtest
+        cd buildtest
+
+        # Step 1: conan install — resolves deps, generates conan_toolchain.cmake
+        poetry run conan install ../.. \
+            -s build_type=RelWithDebInfo \
+            --profile:host vita \
+            --build missing \
+            --output-folder .
+
+        # Source the generated cross-compile env (sets CC/CXX/AR/STRIP/etc)
+        # Pre-initialize variables that the generated file appends to, so that
+        # set -u (nounset) does not abort when they are not already in the
+        # environment (LD_LIBRARY_PATH / DYLD_LIBRARY_PATH are often absent).
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+        export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}"
+        # shellcheck disable=SC1091
+        [[ -f conanbuildenv-relwithdebinfo-armv7.sh ]] && \
+            source conanbuildenv-relwithdebinfo-armv7.sh
+
+        # Step 2: cmake configure — override Title ID and App Name for the test build
+        #         VITA_TITLEID and VITA_APP_NAME are CACHE variables in CMakeLists.txt
+        #         so -D flags here take precedence over the defaults.
+        cmake ../.. \
+            -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DVITA_TITLEID="PKGJ00099" \
+            -DVITA_APP_NAME="PKGj+ TEST"
+
+        # Step 3: cmake build
+        cmake --build .
+
+        [[ -f pkgj ]] && cp pkgj pkgj.elf
+
+        echo ""
+        echo "==> Done.  Package: ci/buildtest/pkgj.vpk"
+        echo "    Title ID PKGJ00099 — safe to install alongside the release build."
+        ;;
+esac

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,142 @@
+# PKGj Source Code Documentation
+
+## Overview
+
+PKGj (toaster-code/pkgj) is a fork of the original [blastrock/pkgj](https://github.com/blastrock/pkgj) homebrew application for the PlayStation Vita. It enables downloading and installing PKG files (PS Vita packages) using TSV/DB sources, BGDL (Background Downloader), and NoNpDrm for bypassing DRM restrictions. The application is written in C++17, features an ImGui-based UI, and is cross-compiled using VitaSDK via Conan and CMake.
+
+This documentation provides a detailed breakdown of the `/src/` directory structure, including the purpose of each file, key classes, functions, and their interactions.
+
+## Architecture
+
+The application follows a modular C++ structure with the following high-level components:
+
+- **Main Entry Point**: `pkgi.cpp` - Handles initialization, main loop, UI rendering, and state management.
+- **Database Management**: Manages title databases from remote sources.
+- **Downloading and Installation**: Handles package downloads, BGDL integration, and installation logic.
+- **User Interface**: ImGui-based UI for navigation, menus, dialogs, and game views.
+- **Utilities and Platform Abstractions**: HTTP, file I/O, crypto, threading, and Vita-specific functions.
+- **Configuration**: Loading and saving user settings.
+
+The main loop in `pkgi.cpp` runs a state machine (StateMain, StateRefreshing, StateError) to handle different application states. It integrates ImGui for UI, processes input, and delegates to specific modules for tasks like refreshing databases or downloading packages.
+
+## File Structure and Descriptions
+
+### Core Files
+
+- **`pkgi.cpp` / `pkgi.hpp`**: Main application logic. `pkgi.hpp` defines platform abstractions, input handling, UI functions, and utility macros. `pkgi.cpp` contains the `main()` function, state management, UI rendering loops (`pkgi_do_head()`, `pkgi_do_main()`, `pkgi_do_tail()`), and integration with other modules. Key functions include `pkgi_start_download()`, `pkgi_refresh_list()`, and mode switching.
+
+- **`config.cpp` / `config.hpp`**: Configuration management. `Config` struct holds settings like sort options, URLs for different content types (games, DLCs, etc.), and filters. Functions `pkgi_load_config()` and `pkgi_save_config()` handle persistence.
+
+### Database Modules
+
+- **`db.cpp` / `db.hpp`**: Core database handling for titles. `TitleDatabase` class manages loading, updating, and querying title lists from remote TSV sources. Supports filtering, sorting, and searching. Key enums: `DbPresence` (installation status), `DbSort`, `Mode` (content types like Games, DLCs). Functions like `reload()`, `update()`, and `get()`.
+
+- **`comppackdb.cpp` / `comppackdb.hpp`**: Compatibility pack database. `CompPackDatabase` handles updates for game and update compatibility packs. Used for patches and base games.
+
+### Downloading and Installation
+
+- **`downloader.cpp` / `downloader.hpp`**: Asynchronous download manager. `Downloader` class queues and processes downloads using threads. Supports different types (`Type` enum: Game, Dlc, etc.). Integrates with BGDL for background downloads. Key methods: `add()`, `get_current_download()`, progress tracking.
+
+- **`download.cpp` / `download.hpp`**: Low-level download logic. Handles HTTP downloads, resume, and error handling. Classes like `DownloadError` for exceptions.
+
+- **`install.cpp` / `install.hpp`**: Installation logic. Functions for installing packages, handling PSP/PSX conversions, and compatibility packs. Struct `CompPackVersion` for version management.
+
+- **`bgdl.cpp` / `bgdl.hpp`**: Background Downloader (BGDL) integration. Functions to start BGDL tasks for Vita's native download system.
+
+### User Interface
+
+- **`imgui.cpp` / `imgui.hpp`**: ImGui integration. Initializes ImGui with Vita fonts and renders UI elements. `init_imgui()` sets up fonts; `pkgi_imgui_render()` draws ImGui data.
+
+- **`menu.cpp` / `menu.hpp`**: Menu system. Handles navigation menus, likely for settings or mode selection.
+
+- **`dialog.cpp` / `dialog.hpp`**: Dialog boxes. `Response` struct for user interactions. Functions for error dialogs, confirmations, and input.
+
+- **`gameview.cpp` / `gameview.hpp`**: Game detail view. `GameView` class displays information about selected games, possibly with images or metadata.
+
+### Networking and HTTP
+
+- **`vitahttp.cpp` / `vitahttp.hpp`**: Vita-specific HTTP client. `VitaHttp` class extends `Http` for PS Vita networking.
+
+- **`filehttp.cpp` / `filehttp.hpp`**: File-based HTTP? `FileHttp` class, possibly for local file handling.
+
+- **`http.hpp`**: Base HTTP interface. `Http` class and `HttpError` exception.
+
+### File and Data Handling
+
+- **`vitafile.cpp`**: Vita file I/O operations.
+
+- **`file.hpp`**: File utilities, enum `InodeType`.
+
+- **`extractzip.cpp` / `extractzip.hpp`**: ZIP extraction, likely for compatibility packs.
+
+- **`sfo.cpp` / `sfo.hpp`**: SFO (System File Object) parsing, used for Vita package metadata.
+
+- **`puff.c` / `puff.h`**: DEFLATE decompression library (from zlib).
+
+### Cryptography and Security
+
+- **`zrif.cpp` / `zrif.hpp`**: ZRIF (zRIF) handling. Functions to decode zRIF strings into RIF (Rights Information File) for DRM.
+
+- **`aes128.cpp` / `aes128.hpp`**: AES-128 encryption/decryption.
+
+- **`sha256.cpp` / `sha256.hpp`**: SHA-256 hashing.
+
+### Platform and Utilities
+
+- **`vita.cpp`**: Vita-specific platform functions (battery, free space, etc.).
+
+- **`psx.cpp` / `psx.hpp`**: PSX (PS1) game handling, including PBP conversion.
+
+- **`psm.hpp`**: PSM (PlayStation Mobile) related constants.
+
+- **`thread.hpp`**: Threading utilities. Classes `Mutex`, `Cond`, `Thread`, `ScopeProcessLock`.
+
+- **`utils.hpp`**: General utilities.
+
+- **`log.hpp`**: Logging macros.
+
+- **`update.cpp` / `update.hpp`**: Application update checking.
+
+- **`patchinfo.cpp` / `patchinfo.hpp` / `patchinfofetcher.cpp` / `patchinfofetcher.hpp`**: Patch information fetching. `PatchInfo` struct, `PatchInfoFetcher` class.
+
+- **`imagefetcher.cpp` / `imagefetcher.hpp`**: Image downloading/caching (game cover).
+
+- **`filedownload.cpp` / `filedownload.hpp`**: File download utilities.
+
+- **`cli.cpp`**: Command-line interface for debugging.
+
+- **`simulator.cpp`**: Simulator mode, perhaps for PC testing.
+
+- **`sqlite.hpp`**: SQLite wrapper.
+
+- **`style.h`**: UI style definitions.
+
+## Key Classes and Interactions
+
+- **TitleDatabase**: Loads and manages title lists. Interacts with HTTP for updates, filters based on config.
+
+- **Downloader**: Queues downloads, uses threads for async processing. Calls refresh callbacks on completion.
+
+- **GameView**: Displays game details, possibly fetches images via ImageFetcher.
+
+- **Http / VitaHttp**: Base for all network operations. Used by databases and downloaders.
+
+- **DbItem**: Struct representing a title, with fields like titleid, name, size, presence.
+
+- **DownloadItem**: Struct for queued downloads, including RIF data.
+
+The UI (ImGui) is rendered in the main loop, with menus, dialogs, and views overlaying the main list.
+
+## Build and Dependencies
+
+Built with CMake and Conan for VitaSDK. Dependencies include Vita2D, ImGui, SQLite, and crypto libraries. Conan manages packages like Boost, BZip2, cereal.
+
+## Differences from Original blastrock/pkgj
+
+This fork include enhancements like improved UI, additional modes, some bug fixes and probably new bugs. refer to commit history for modifications.
+
+## Usage
+
+The app runs on PS Vita with HENkaku. Users select modes (Games, DLCs, etc.), refresh lists, and download/install packages. BGDL allows background downloads.
+
+For development, use the provided CMake/Conan setup to build for Vita.

--- a/ci/conan-vitasdk/conanfile.py
+++ b/ci/conan-vitasdk/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools import files
 class VitasdkToolchainConan(ConanFile):
     name = "vitasdk-toolchain"
     lib_version = "2.527"
-    package_version = ""
+    package_version = ".1"
     exports_sources = "cmake-toolchain.patch"
     version = "%s%s" % (lib_version, package_version)
     settings = "os", "arch"
@@ -27,6 +27,9 @@ class VitasdkToolchainConan(ConanFile):
             "libpng",
             "libjpeg-turbo",
             "taihen",
+            "openssl",
+            "zstd",
+            "curl",
         ]
         for lib in additional_libs:
             lib = "{}.tar.xz".format(lib)

--- a/ci/conan/profiles/vita
+++ b/ci/conan/profiles/vita
@@ -1,5 +1,5 @@
 [tool_requires]
-vitasdk-toolchain/2.527@blastrock/pkgj
+vitasdk-toolchain/2.527.1@blastrock/pkgj
 
 [settings]
 os=PSVita

--- a/ci/pyproject.toml
+++ b/ci/pyproject.toml
@@ -3,7 +3,7 @@ name = "pkgj-ci"
 version = "0.1.0"
 description = ""
 authors = ["Philippe Daouadi <philippe@ud2.org>"]
-readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/ci/setup_conan.sh
+++ b/ci/setup_conan.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-poetry install
+poetry install --no-root
 
 # create home dirs
 poetry run conan

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,9 +9,11 @@ class PkgjConan(ConanFile):
     def requirements(self):
         if self.settings.os == "PSVita":
             self.requires("vitasqlite/0.0.2@blastrock/pkgj")
-            self.requires("imgui/1.89.4")
         else:
             self.requires("sqlite3/3.42.0")
+
+        # imgui is used by both the Vita build and the Linux graphical simulator
+        self.requires("imgui/1.89.4")
 
         self.requires("boost/1.82.0")
         self.requires("libzip/1.9.2@blastrock/pkgj")

--- a/cross.cmake
+++ b/cross.cmake
@@ -57,11 +57,13 @@ add_executable(pkgj
   src/comppackdb.cpp
   src/config.cpp
   src/db.cpp
+  src/customhandler.cpp
   src/dialog.cpp
   src/download.cpp
   src/downloader.cpp
   src/extractzip.cpp
   src/filedownload.cpp
+  src/browserview.cpp
   src/gameview.cpp
   src/logbuffer.cpp
   src/logviewer.cpp

--- a/cross.cmake
+++ b/cross.cmake
@@ -51,7 +51,9 @@ add_assets(assets
 add_executable(pkgj
   ${assets}
   src/aes128.cpp
+  src/annotationdb.cpp
   src/bgdl.cpp
+  src/configeditor.cpp
   src/comppackdb.cpp
   src/config.cpp
   src/db.cpp
@@ -61,6 +63,8 @@ add_executable(pkgj
   src/extractzip.cpp
   src/filedownload.cpp
   src/gameview.cpp
+  src/logbuffer.cpp
+  src/logviewer.cpp
   src/patchinfo.cpp
   src/patchinfofetcher.cpp
   src/psx.cpp
@@ -76,8 +80,11 @@ add_executable(pkgj
   src/vita.cpp
   src/vitafile.cpp
   src/vitahttp.cpp
+  src/curlhttp.cpp
   src/zrif.cpp
 )
+
+target_link_options(pkgj PRIVATE -Wl,--wrap,fcntl)
 
 target_link_libraries(pkgj
   vita2d
@@ -97,6 +104,10 @@ target_link_libraries(pkgj
   SceCtrl_stub
   SceDisplay_stub
   SceGxm_stub
+  curl
+  ssl
+  crypto
+  zstd
   SceHttp_stub
   SceNet_stub
   SceNetCtl_stub

--- a/cross.cmake
+++ b/cross.cmake
@@ -65,6 +65,8 @@ add_executable(pkgj
   src/filedownload.cpp
   src/browserview.cpp
   src/gameview.cpp
+  src/descriptionfetcher.cpp
+  src/screenshotfetcher.cpp
   src/logbuffer.cpp
   src/logviewer.cpp
   src/patchinfo.cpp

--- a/host.cmake
+++ b/host.cmake
@@ -1,11 +1,13 @@
 find_package(SQLite3 REQUIRED)
 
 add_executable(pkgj_cli
+  src/annotationdb.cpp
   src/comppackdb.cpp
   src/db.cpp
   src/download.cpp
   src/extractzip.cpp
   src/filedownload.cpp
+  src/logbuffer.cpp
   src/patchinfo.cpp
   src/simulator.cpp
   src/aes128.cpp
@@ -24,3 +26,86 @@ target_link_libraries(pkgj_cli
   cereal::cereal
   libzip::zip
 )
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Graphical simulator — pkgj_sim
+#
+# Requires:
+#   libsdl2-dev  libsdl2-ttf-dev  libsdl2-image-dev  libcurl-dev
+#
+# Enable with:  cmake ../.. -DBUILD_SIM=ON   (inside ci/buildhost/)
+# ─────────────────────────────────────────────────────────────────────────────
+option(BUILD_SIM "Build the pkgj graphical SDL2 simulator" OFF)
+
+if(BUILD_SIM)
+  find_package(imgui REQUIRED)
+  find_package(CURL REQUIRED)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(SDL2       REQUIRED IMPORTED_TARGET sdl2)
+  pkg_check_modules(SDL2_TTF   REQUIRED IMPORTED_TARGET SDL2_ttf)
+  pkg_check_modules(SDL2_IMAGE REQUIRED IMPORTED_TARGET SDL2_image)
+
+  add_executable(pkgj_sim
+    # ── Core portable UI ─────────────────────────────────────────────────────
+    src/pkgi.cpp
+    src/annotationdb.cpp
+    src/comppackdb.cpp
+    src/config.cpp
+    src/configeditor.cpp
+    src/db.cpp
+    src/dialog.cpp
+    src/download.cpp
+    src/downloader.cpp
+    src/extractzip.cpp
+    src/filedownload.cpp
+    src/filehttp.cpp
+    src/gameview.cpp
+    src/imagefetcher.cpp
+    src/curlhttp.cpp
+    src/thumbnailfetcher.cpp
+    src/logbuffer.cpp
+    src/logviewer.cpp
+    src/menu.cpp
+    src/patchinfo.cpp
+    src/patchinfofetcher.cpp
+    src/aes128.cpp
+    src/sfo.cpp
+    src/sha256.cpp
+    src/zrif.cpp
+    src/puff.c
+    # ── POSIX platform helpers ────────────────────────────────────────────────
+    src/simulator.cpp
+    # ── Simulator-specific implementations ───────────────────────────────────
+    simulator/sdl_backend.cpp   # replaces vita.cpp  (rendering + input)
+    simulator/imgui_sdl.cpp     # replaces imgui.cpp (ImGui SDL renderer)
+    simulator/bgdl_stub.cpp     # replaces bgdl.cpp  (no LiveArea queue)
+    simulator/install_stub.cpp  # replaces install.cpp (no pkg install)
+    simulator/vitahttp_stub.cpp # replaces vitahttp.cpp (libcurl-based HTTP)
+    simulator/update_stub.cpp   # replaces update.cpp (no auto-update)
+    simulator/sim_file.cpp      # extra POSIX file helpers
+  )
+
+  target_compile_definitions(pkgj_sim PRIVATE PKGI_SIMULATOR)
+
+  target_include_directories(pkgj_sim PRIVATE
+    src/
+    ${SDL2_INCLUDE_DIRS}
+    ${SDL2_TTF_INCLUDE_DIRS}
+    ${SDL2_IMAGE_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(pkgj_sim
+    fmt::fmt
+    Boost::headers
+    SQLite::SQLite3
+    cereal::cereal
+    libzip::zip
+    imgui::imgui
+    PkgConfig::SDL2
+    PkgConfig::SDL2_TTF
+    PkgConfig::SDL2_IMAGE
+    CURL::libcurl
+  )
+
+  message(STATUS "pkgj_sim: graphical simulator target enabled")
+endif()

--- a/host.cmake
+++ b/host.cmake
@@ -62,6 +62,8 @@ if(BUILD_SIM)
     src/filehttp.cpp
     src/browserview.cpp
     src/gameview.cpp
+    src/descriptionfetcher.cpp
+    src/screenshotfetcher.cpp
     src/imagefetcher.cpp
     src/curlhttp.cpp
     src/thumbnailfetcher.cpp

--- a/host.cmake
+++ b/host.cmake
@@ -52,6 +52,7 @@ if(BUILD_SIM)
     src/comppackdb.cpp
     src/config.cpp
     src/configeditor.cpp
+    src/customhandler.cpp
     src/db.cpp
     src/dialog.cpp
     src/download.cpp
@@ -59,6 +60,7 @@ if(BUILD_SIM)
     src/extractzip.cpp
     src/filedownload.cpp
     src/filehttp.cpp
+    src/browserview.cpp
     src/gameview.cpp
     src/imagefetcher.cpp
     src/curlhttp.cpp

--- a/send_to_linux.sh
+++ b/send_to_linux.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Deploy pkgj_cli or pkgj_sim from ci/buildhost to a local Linux destination.
+#
+# Usage:
+#   ./send_to_linux.sh                  # interactive: pick from ci/buildhost/
+#   ./send_to_linux.sh ci/buildhost/pkgj_cli
+#   ./send_to_linux.sh ci/buildhost/pkgj_sim
+#   DEPLOY_DIR=/opt/pkgj ./send_to_linux.sh
+
+set -e
+
+DEPLOY_DIR="${DEPLOY_DIR:-/home/ubuntu/.local/bin}"
+BINARY="${1:-}"
+USED_DEFAULT=0
+
+COLOR_RESET="\033[0m"
+COLOR_GREEN="\033[1;32m"
+COLOR_YELLOW="\033[1;33m"
+COLOR_CYAN="\033[1;36m"
+COLOR_RED="\033[1;31m"
+
+get_file_timestamp() {
+    local path="$1"
+    local modified
+    modified=$(stat -c '%y' "$path" 2>/dev/null || true)
+    if [ -n "$modified" ]; then
+        printf '%s' "${modified%%.*}"
+    else
+        printf '%s' "unknown"
+    fi
+}
+
+choose_binary_interactively() {
+    local choices=()
+    local choice
+    local index=1
+    local newest_path=""
+    local newest_mtime=0
+    local path_mtime
+
+    while IFS= read -r path; do
+        choices+=("$path")
+        path_mtime=$(stat -c '%Y' "$path" 2>/dev/null || printf '0')
+        if [ "$path_mtime" -gt "$newest_mtime" ]; then
+            newest_mtime="$path_mtime"
+            newest_path="$path"
+        fi
+    done < <({
+        find ci/build ci/buildtest -maxdepth 1 -type f -name '*.vpk'
+        find ci/buildhost -maxdepth 1 -type f \( -name 'pkgj_cli' -o -name 'pkgj_sim' \)
+    } | sort)
+
+    if [ ${#choices[@]} -eq 0 ]; then
+        echo -e "${COLOR_RED}[!] No supported build outputs found.${COLOR_RESET}"
+        echo "    Expected .vpk packages in ci/build or ci/buildtest, or pkgj_cli/pkgj_sim in ci/buildhost."
+        exit 1
+    fi
+
+    echo "[*] No binary argument provided. Available builds:"
+    for path in "${choices[@]}"; do
+        if [ "$path" = "$newest_path" ]; then
+            printf '    %d) %b%s%b  [%s]  %b%s%b\n' \
+                "$index" \
+                "$COLOR_GREEN" "$path" "$COLOR_RESET" \
+                "$(get_file_timestamp "$path")" \
+                "$COLOR_YELLOW" "<-- newest" "$COLOR_RESET"
+        else
+            printf '    %d) %s  [%s]\n' \
+                "$index" "$path" "$(get_file_timestamp "$path")"
+        fi
+        index=$((index + 1))
+    done
+
+    while true; do
+        printf '[?] Choose a binary to deploy [1-%d] (Enter for newest): ' "${#choices[@]}"
+        read -r choice
+
+        if [ -z "$choice" ]; then
+            BINARY="$newest_path"
+            return
+        fi
+
+        if [[ "$choice" =~ ^[0-9]+$ ]] && \
+           [ "$choice" -ge 1 ] && \
+           [ "$choice" -le "${#choices[@]}" ]; then
+            BINARY="${choices[$((choice - 1))]}"
+            return
+        fi
+
+        echo -e "${COLOR_YELLOW}[!] Invalid choice.${COLOR_RESET} Enter a number from the list or press Enter for newest."
+    done
+}
+
+# ── Pick binary ───────────────────────────────────────────────────────────────
+
+if [ $# -eq 0 ]; then
+    USED_DEFAULT=1
+    choose_binary_interactively
+fi
+
+if [ ! -f "$BINARY" ]; then
+    echo -e "${COLOR_RED}[!] File not found:${COLOR_RESET} $BINARY"
+    echo "    Usage: $0 [ci/buildhost/pkgj_cli | ci/buildhost/pkgj_sim]"
+    exit 1
+fi
+
+DEST_NAME="$(basename "$BINARY")"
+DEST_PATH="$DEPLOY_DIR/$DEST_NAME"
+
+REMOTE_HOST="192.168.0.199"
+
+# Removendo sshpass e ajustando para usar apenas ssh com chave
+SSH_USER="ubuntu"
+
+# ── Deploy ────────────────────────────────────────────────────────────────────
+
+echo -e "[*] Binary  : ${COLOR_CYAN}${BINARY}${COLOR_RESET}  [$(get_file_timestamp "$BINARY")]"
+echo -e "[*] Remote : ${COLOR_GREEN}${SSH_USER}@${REMOTE_HOST}:${DEST_PATH}${COLOR_RESET}"
+if [ "$USED_DEFAULT" -eq 1 ]; then
+    echo -e "${COLOR_YELLOW}[!] Nenhum argumento fornecido: usando seleção interativa.${COLOR_RESET}"
+fi
+
+ssh "$SSH_USER@$REMOTE_HOST" "mkdir -p \"$DEPLOY_DIR\""
+scp "$BINARY" "$SSH_USER@$REMOTE_HOST:$DEST_PATH"
+ssh "$SSH_USER@$REMOTE_HOST" "chmod +x \"$DEST_PATH\""
+
+echo -e "${COLOR_GREEN}[OK]${COLOR_RESET} Copiado para $SSH_USER@$REMOTE_HOST:$DEST_PATH"
+
+# Inform user if DEPLOY_DIR is not in PATH on the remote machine
+if ! echo ":$PATH:" | grep -q ":$DEPLOY_DIR:"; then
+    echo -e "\033[1;33m[!] Aviso:\033[0m '$DEPLOY_DIR' não está no seu PATH."
+    echo "    Adicione ao ~/.bashrc ou ~/.profile:"
+    echo "        export PATH=\"\$PATH:$DEPLOY_DIR\""
+fi

--- a/simulator/bgdl_stub.cpp
+++ b/simulator/bgdl_stub.cpp
@@ -1,0 +1,22 @@
+// bgdl_stub.cpp
+// Stub implementation of bgdl.hpp for the pkgj Linux simulator.
+// Background download (LiveArea queue) is not available on PC;
+// calls are silently ignored.
+
+#include "bgdl.hpp"
+
+#include <cstdio>
+
+void pkgi_start_bgdl(
+        const int type,
+        const std::string& title,
+        const std::string& url,
+        const std::vector<uint8_t>& rif)
+{
+    (void)type;
+    (void)rif;
+    fprintf(stderr,
+            "[sim] pkgi_start_bgdl: bgdl not supported in simulator "
+            "(title=%s, url=%s)\n",
+            title.c_str(), url.c_str());
+}

--- a/simulator/imgui_sdl.cpp
+++ b/simulator/imgui_sdl.cpp
@@ -1,0 +1,133 @@
+// imgui_sdl.cpp
+// SDL2-based ImGui render backend for the pkgj Linux simulator.
+// Replaces the vita2d/GXM imgui.cpp that is used in Vita builds.
+//
+// Uses SDL_RenderGeometry (SDL 2.0.18+) to draw ImGui triangles via the
+// existing SDL_Renderer managed by sdl_backend.cpp.
+
+#include "imgui.hpp"
+
+#include <imgui.h>
+#include <SDL2/SDL.h>
+
+#include <cstdio>
+#include <cstring>
+
+// Provided by sdl_backend.cpp
+extern SDL_Renderer* g_sdl_renderer;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// init_imgui
+// ──────────────────────────────────────────────────────────────────────────────
+// No-op for the SDL path: ImGui context creation and font-texture upload are
+// handled entirely inside sim_main.cpp (analogous to pkgi.cpp's main()).
+void init_imgui()
+{
+    // Nothing to do — ImGui is set up in sim_main.cpp before the render loop.
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// pkgi_imgui_render
+// ──────────────────────────────────────────────────────────────────────────────
+// Renders an ImGui draw-list using SDL_RenderGeometry.
+//
+// SDL_RenderGeometry requires SDL 2.0.18 or newer.  On older distributions
+// you can downgrade this path to fill each triangle with plain
+// SDL_RenderFillRect calls (lossy but functional).
+void pkgi_imgui_render(ImDrawData* draw_data)
+{
+    if (!draw_data || draw_data->CmdListsCount == 0)
+        return;
+
+    SDL_Renderer* renderer = g_sdl_renderer;
+
+    // Save SDL renderer state
+    SDL_Rect saved_clip;
+    bool had_clip = (SDL_RenderIsClipEnabled(renderer) == SDL_TRUE);
+    SDL_RenderGetClipRect(renderer, &saved_clip);
+
+    // ImGui display sizing
+    const float fb_x = draw_data->DisplayPos.x;
+    const float fb_y = draw_data->DisplayPos.y;
+
+    for (int list_idx = 0; list_idx < draw_data->CmdListsCount; ++list_idx)
+    {
+        const ImDrawList* cmd_list = draw_data->CmdLists[list_idx];
+
+        // Build vertex and index buffers in SDL format
+        // SDL_Vertex: position (float x,y), color (SDL_Color), tex_coord (float u,v)
+        const int vert_count = cmd_list->VtxBuffer.Size;
+        const int idx_count  = cmd_list->IdxBuffer.Size;
+
+        // Allocate temporary buffers on the stack if small enough, else heap
+        SDL_Vertex* sdl_verts   = new SDL_Vertex[vert_count];
+        int*        sdl_indices = new int[idx_count];
+
+        for (int i = 0; i < vert_count; ++i)
+        {
+            const ImDrawVert& v = cmd_list->VtxBuffer[i];
+            sdl_verts[i].position.x = v.pos.x;
+            sdl_verts[i].position.y = v.pos.y;
+            sdl_verts[i].color.r    = static_cast<Uint8>((v.col >>  0) & 0xFF);
+            sdl_verts[i].color.g    = static_cast<Uint8>((v.col >>  8) & 0xFF);
+            sdl_verts[i].color.b    = static_cast<Uint8>((v.col >> 16) & 0xFF);
+            sdl_verts[i].color.a    = static_cast<Uint8>((v.col >> 24) & 0xFF);
+            sdl_verts[i].tex_coord.x = v.uv.x;
+            sdl_verts[i].tex_coord.y = v.uv.y;
+        }
+
+        for (int i = 0; i < idx_count; ++i)
+            sdl_indices[i] = static_cast<int>(cmd_list->IdxBuffer[i]);
+
+        // Execute draw commands
+        int idx_offset = 0;
+        for (int cmd_idx = 0; cmd_idx < cmd_list->CmdBuffer.Size; ++cmd_idx)
+        {
+            const ImDrawCmd& pcmd = cmd_list->CmdBuffer[cmd_idx];
+
+            if (pcmd.UserCallback)
+            {
+                pcmd.UserCallback(cmd_list, &pcmd);
+                idx_offset += static_cast<int>(pcmd.ElemCount);
+                continue;
+            }
+
+            // Scissor / clip rect
+            const ImVec4 clip = pcmd.ClipRect;
+            SDL_Rect clip_rect{
+                static_cast<int>(clip.x - fb_x),
+                static_cast<int>(clip.y - fb_y),
+                static_cast<int>(clip.z - clip.x),
+                static_cast<int>(clip.w - clip.y)
+            };
+            if (clip_rect.w <= 0 || clip_rect.h <= 0)
+            {
+                idx_offset += static_cast<int>(pcmd.ElemCount);
+                continue;
+            }
+            SDL_RenderSetClipRect(renderer, &clip_rect);
+
+            SDL_Texture* tex = static_cast<SDL_Texture*>(
+                    reinterpret_cast<void*>(pcmd.TextureId));
+
+            SDL_RenderGeometry(
+                    renderer,
+                    tex,
+                    sdl_verts,
+                    vert_count,
+                    sdl_indices + idx_offset,
+                    static_cast<int>(pcmd.ElemCount));
+
+            idx_offset += static_cast<int>(pcmd.ElemCount);
+        }
+
+        delete[] sdl_verts;
+        delete[] sdl_indices;
+    }
+
+    // Restore SDL clip state
+    if (had_clip)
+        SDL_RenderSetClipRect(renderer, &saved_clip);
+    else
+        SDL_RenderSetClipRect(renderer, nullptr);
+}

--- a/simulator/install_stub.cpp
+++ b/simulator/install_stub.cpp
@@ -1,0 +1,103 @@
+// install_stub.cpp
+// Stub implementations of install.hpp for the pkgj Linux simulator.
+// Installation and content-presence detection are not available on PC;
+// all queries return "not installed" and install operations are no-ops.
+
+#include "install.hpp"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+std::vector<std::string> pkgi_get_installed_games()
+{
+    return {};
+}
+
+std::vector<std::string> pkgi_get_installed_themes()
+{
+    return {};
+}
+
+std::string pkgi_get_game_version(const std::string& titleid)
+{
+    (void)titleid;
+    return "";
+}
+
+CompPackVersion pkgi_get_comppack_versions(const std::string& titleid)
+{
+    (void)titleid;
+    return {false, "", ""};
+}
+
+bool pkgi_dlc_is_installed(const char* content)
+{
+    (void)content;
+    return false;
+}
+
+bool pkgi_psm_is_installed(const char* titleid)
+{
+    (void)titleid;
+    return false;
+}
+
+bool pkgi_psp_is_installed(const char* psppartition, const char* content)
+{
+    (void)psppartition;
+    (void)content;
+    return false;
+}
+
+bool pkgi_psx_is_installed(const char* psppartition, const char* content)
+{
+    (void)psppartition;
+    (void)content;
+    return false;
+}
+
+void pkgi_install(const char* contentid)
+{
+    fprintf(stderr, "[sim] pkgi_install(%s): not supported in simulator\n",
+            contentid);
+}
+
+void pkgi_install_update(const std::string& titleid)
+{
+    fprintf(stderr, "[sim] pkgi_install_update(%s): not supported\n",
+            titleid.c_str());
+}
+
+void pkgi_install_comppack(
+        const std::string& titleid, bool patch, const std::string& version)
+{
+    fprintf(stderr,
+            "[sim] pkgi_install_comppack(%s, patch=%d, ver=%s): not supported\n",
+            titleid.c_str(), patch, version.c_str());
+}
+
+void pkgi_install_psmgame(const char* contentid)
+{
+    fprintf(stderr, "[sim] pkgi_install_psmgame(%s): not supported\n",
+            contentid);
+}
+
+void pkgi_install_pspgame(const char* partition, const char* contentid)
+{
+    fprintf(stderr, "[sim] pkgi_install_pspgame(%s, %s): not supported\n",
+            partition, contentid);
+}
+
+void pkgi_install_pspgame_as_iso(const char* partition, const char* contentid)
+{
+    fprintf(stderr,
+            "[sim] pkgi_install_pspgame_as_iso(%s, %s): not supported\n",
+            partition, contentid);
+}
+
+void pkgi_install_pspdlc(const char* partition, const char* contentid)
+{
+    fprintf(stderr, "[sim] pkgi_install_pspdlc(%s, %s): not supported\n",
+            partition, contentid);
+}

--- a/simulator/sdl_backend.cpp
+++ b/simulator/sdl_backend.cpp
@@ -394,6 +394,11 @@ void pkgi_draw_rect(int x, int y, int w, int h, uint32_t color)
 
 void pkgi_draw_text(int x, int y, uint32_t color, const char* text)
 {
+    pkgi_draw_text_scale(x, y, color, text, 1.f);
+}
+
+void pkgi_draw_text_scale(int x, int y, uint32_t color, const char* text, float scale)
+{
     if (!g_font || !text || !*text)
         return;
 
@@ -414,7 +419,11 @@ void pkgi_draw_text(int x, int y, uint32_t color, const char* text)
     SDL_QueryTexture(tex, nullptr, nullptr, &tw, &th);
 
     // vita.cpp draws at y+20 (font ascent offset) — replicate here
-    SDL_Rect dst{x, y + 2, tw, th};
+    SDL_Rect dst{
+            x,
+            y + 2,
+            static_cast<int>(tw * scale),
+            static_cast<int>(th * scale)};
     SDL_RenderCopy(g_sdl_renderer, tex, nullptr, &dst);
     SDL_DestroyTexture(tex);
 }

--- a/simulator/sdl_backend.cpp
+++ b/simulator/sdl_backend.cpp
@@ -30,6 +30,7 @@ extern "C"
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <dirent.h>
 #include <mutex>
@@ -128,7 +129,15 @@ static uint32_t sdl_key_to_button(SDL_Keycode k)
 // Font helpers
 // ──────────────────────────────────────────────────────────────────────────────
 // Preferred font search order (first that exists is used).
+// Include Japanese-capable fonts first so the simulator can render JPN text.
 static const char* FONT_CANDIDATES[] = {
+    "/usr/share/fonts/truetype/noto/NotoSansCJKjp-Regular.otf",
+    "/usr/share/fonts/truetype/noto/NotoSansCJKjp-Regular.ttf",
+    "/usr/share/fonts/opentype/noto/NotoSansCJKjp-Regular.otf",
+    "/usr/share/fonts/opentype/noto/NotoSansCJKjp-Regular.ttf",
+    "/usr/share/fonts/truetype/fonts-japanese-gothic.ttf",
+    "/usr/share/fonts/truetype/fonts-japanese-mincho.ttf",
+    "/usr/share/fonts/truetype/vlgothic/VL-Gothic-Regular.ttf",
     "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
     "/usr/share/fonts/TTF/DejaVuSans.ttf",
     "/usr/share/fonts/dejavu/DejaVuSans.ttf",
@@ -139,20 +148,57 @@ static const char* FONT_CANDIDATES[] = {
     nullptr
 };
 
-static TTF_Font* load_best_font(int ptsize)
+static bool load_font_file(const char* path, int ptsize, TTF_Font** out)
 {
-    for (int i = 0; FONT_CANDIDATES[i]; ++i)
+    if (access(path, R_OK) != 0)
+        return false;
+    TTF_Font* font = TTF_OpenFont(path, ptsize);
+    if (!font)
+        return false;
+
+    printf("[sim] Loaded font: %s\n", path);
+    *out = font;
+    return true;
+}
+
+static bool load_font_via_fc_match(int ptsize, TTF_Font** out)
+{
+    FILE* pipe = popen("fc-match -s -f '%{file}\\n' :lang=ja", "r");
+    if (!pipe)
+        return false;
+
+    char path[1024];
+    while (fgets(path, sizeof(path), pipe))
     {
-        if (access(FONT_CANDIDATES[i], R_OK) == 0)
+        size_t len = strlen(path);
+        if (len == 0)
+            continue;
+        if (path[len - 1] == '\n')
+            path[len - 1] = '\0';
+
+        if (load_font_file(path, ptsize, out))
         {
-            TTF_Font* f = TTF_OpenFont(FONT_CANDIDATES[i], ptsize);
-            if (f)
-            {
-                printf("[sim] Loaded font: %s\n", FONT_CANDIDATES[i]);
-                return f;
-            }
+            pclose(pipe);
+            return true;
         }
     }
+
+    pclose(pipe);
+    return false;
+}
+
+static TTF_Font* load_best_font(int ptsize)
+{
+    TTF_Font* font = nullptr;
+    if (load_font_via_fc_match(ptsize, &font))
+        return font;
+
+    for (int i = 0; FONT_CANDIDATES[i]; ++i)
+    {
+        if (load_font_file(FONT_CANDIDATES[i], ptsize, &font))
+            return font;
+    }
+
     // fall back to whatever TTF_OpenFont can find
     fprintf(stderr, "[sim] WARNING: no preferred font found; text will be blank\n");
     return nullptr;

--- a/simulator/sdl_backend.cpp
+++ b/simulator/sdl_backend.cpp
@@ -406,7 +406,9 @@ void pkgi_draw_text_scale(int x, int y, uint32_t color, const char* text, float 
         static_cast<Uint8>(color & 0xFF),
         static_cast<Uint8>((color >> 8) & 0xFF),
         static_cast<Uint8>((color >> 16) & 0xFF),
-        255};
+        static_cast<Uint8>(color >> 24)};
+    if (c.a == 0)
+        c.a = 255;
 
     SDL_Surface* surf = TTF_RenderUTF8_Blended(g_font, text, c);
     if (!surf) return;

--- a/simulator/sdl_backend.cpp
+++ b/simulator/sdl_backend.cpp
@@ -1,0 +1,556 @@
+// sdl_backend.cpp
+// SDL2-based platform backend for the pkgj graphical simulator on Linux.
+// Replaces vita.cpp for the PKGI_SIMULATOR build.
+//
+// Provides:
+//   - SDL2 window / renderer initialisation
+//   - Keyboard → Vita button mapping
+//   - SDL2_ttf text rendering
+//   - SDL2_image PNG texture loading
+//   - Clip-rect support
+//   - Thread helpers via std::thread
+//   - Stub implementations for battery, config folder, free-space, etc.
+
+#include "pkgi.hpp"
+
+extern "C"
+{
+#include "style.h"
+}
+
+#include "config.hpp"
+#include "file.hpp"
+#include "log.hpp"
+
+#include <fmt/format.h>
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+#include <SDL2/SDL_ttf.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <dirent.h>
+#include <mutex>
+#include <stdarg.h>
+#include <stdexcept>
+#include <string>
+#include <sys/statvfs.h>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Globals shared with imgui_sdl.cpp
+// ──────────────────────────────────────────────────────────────────────────────
+SDL_Renderer* g_sdl_renderer = nullptr;   // exposed for ImGui SDL backend
+SDL_Window*   g_sdl_window   = nullptr;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Private statics
+// ──────────────────────────────────────────────────────────────────────────────
+static TTF_Font* g_font       = nullptr;
+static bool      g_clipping   = false;
+static SDL_Rect  g_clip_rect  = {0, 0, VITA_WIDTH, VITA_HEIGHT};
+
+static uint32_t g_button_frame_count = 0;
+static uint64_t g_time_ms            = 0;
+static uint32_t g_current_down       = 0; // buttons currently held
+
+// Dialog / IME state
+static std::mutex  g_dialog_mutex;
+static bool        g_ime_active    = false;
+static bool        g_ime_confirmed = false; // set when user presses Enter
+static std::string g_ime_title;
+static std::string g_ime_input; // text typed so far
+
+// OK / Cancel button assignment (X = ok, O = cancel, matching western style)
+static int g_ok_button     = PKGI_BUTTON_X;
+static int g_cancel_button = PKGI_BUTTON_O;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Color helper
+// ──────────────────────────────────────────────────────────────────────────────
+// pkgj color format is 0xBBGGRR (R in lowest byte).
+static void sdl_set_color(SDL_Renderer* r, uint32_t c)
+{
+    SDL_SetRenderDrawColor(r,
+        c & 0xFF,
+        (c >> 8) & 0xFF,
+        (c >> 16) & 0xFF,
+        255);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Keyboard → Vita button mapping
+// ──────────────────────────────────────────────────────────────────────────────
+struct KeyMap { SDL_Keycode key; uint32_t button; };
+
+static constexpr KeyMap KEY_TABLE[] = {
+    // D-Pad
+    { SDLK_UP,        PKGI_BUTTON_UP    },
+    { SDLK_DOWN,      PKGI_BUTTON_DOWN  },
+    { SDLK_LEFT,      PKGI_BUTTON_LEFT  },
+    { SDLK_RIGHT,     PKGI_BUTTON_RIGHT },
+    // WASD (alternative D-Pad)
+    { SDLK_w,         PKGI_BUTTON_UP    },
+    { SDLK_s,         PKGI_BUTTON_DOWN  },
+    { SDLK_a,         PKGI_BUTTON_LEFT  },
+    { SDLK_d,         PKGI_BUTTON_RIGHT },
+    // Face buttons
+    { SDLK_RETURN,    PKGI_BUTTON_X     }, // Enter  = Cross  (confirm)
+    { SDLK_KP_ENTER,  PKGI_BUTTON_X     },
+    { SDLK_ESCAPE,    PKGI_BUTTON_O     }, // Esc    = Circle (cancel)
+    { SDLK_BACKSPACE, PKGI_BUTTON_O     }, // Bksp   = Circle (cancel)
+    { SDLK_t,         PKGI_BUTTON_T     }, // T      = Triangle
+    { SDLK_F1,        PKGI_BUTTON_T     }, // F1     = Triangle (alt)
+    { SDLK_SPACE,     PKGI_BUTTON_S     }, // Space  = Square
+    { SDLK_F2,        PKGI_BUTTON_S     },
+    // Shoulders
+    { SDLK_q,         PKGI_BUTTON_LT    }, // Q  = L-trigger
+    { SDLK_e,         PKGI_BUTTON_RT    }, // E  = R-trigger
+    { SDLK_PAGEUP,    PKGI_BUTTON_LT    },
+    { SDLK_PAGEDOWN,  PKGI_BUTTON_RT    },
+    // Select / Start
+    { SDLK_TAB,       PKGI_BUTTON_SELECT },
+    { SDLK_F10,       PKGI_BUTTON_START  },
+};
+
+static uint32_t sdl_key_to_button(SDL_Keycode k)
+{
+    for (const auto& km : KEY_TABLE)
+        if (km.key == k) return km.button;
+    return 0;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Font helpers
+// ──────────────────────────────────────────────────────────────────────────────
+// Preferred font search order (first that exists is used).
+static const char* FONT_CANDIDATES[] = {
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/TTF/DejaVuSans.ttf",
+    "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+    "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+    "/usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf",
+    nullptr
+};
+
+static TTF_Font* load_best_font(int ptsize)
+{
+    for (int i = 0; FONT_CANDIDATES[i]; ++i)
+    {
+        if (access(FONT_CANDIDATES[i], R_OK) == 0)
+        {
+            TTF_Font* f = TTF_OpenFont(FONT_CANDIDATES[i], ptsize);
+            if (f)
+            {
+                printf("[sim] Loaded font: %s\n", FONT_CANDIDATES[i]);
+                return f;
+            }
+        }
+    }
+    // fall back to whatever TTF_OpenFont can find
+    fprintf(stderr, "[sim] WARNING: no preferred font found; text will be blank\n");
+    return nullptr;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// pkgi_start / pkgi_end
+// ──────────────────────────────────────────────────────────────────────────────
+void pkgi_start(void)
+{
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0)
+        throw std::runtime_error(
+                fmt::format("SDL_Init failed: {}", SDL_GetError()));
+
+    if (TTF_Init() != 0)
+        throw std::runtime_error(
+                fmt::format("TTF_Init failed: {}", TTF_GetError()));
+
+    int img_flags = IMG_INIT_PNG;
+    if ((IMG_Init(img_flags) & img_flags) != img_flags)
+        fprintf(stderr, "[sim] WARNING: IMG_Init PNG failed: %s\n",
+                IMG_GetError());
+
+    g_sdl_window = SDL_CreateWindow(
+            "PKGj Simulator",
+            SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+            VITA_WIDTH, VITA_HEIGHT,
+            SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE);
+    if (!g_sdl_window)
+        throw std::runtime_error(
+                fmt::format("SDL_CreateWindow failed: {}", SDL_GetError()));
+
+    g_sdl_renderer = SDL_CreateRenderer(
+            g_sdl_window, -1,
+            SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (!g_sdl_renderer)
+        throw std::runtime_error(
+                fmt::format("SDL_CreateRenderer failed: {}", SDL_GetError()));
+
+    // Scale renderer output to always match 960×544 logical size
+    SDL_RenderSetLogicalSize(g_sdl_renderer, VITA_WIDTH, VITA_HEIGHT);
+
+    g_font = load_best_font(17);
+
+    g_time_ms = SDL_GetTicks();
+}
+
+void pkgi_end(void)
+{
+    if (g_font)        { TTF_CloseFont(g_font);                g_font = nullptr; }
+    if (g_sdl_renderer){ SDL_DestroyRenderer(g_sdl_renderer); g_sdl_renderer = nullptr; }
+    if (g_sdl_window)  { SDL_DestroyWindow(g_sdl_window);     g_sdl_window = nullptr; }
+    IMG_Quit();
+    TTF_Quit();
+    SDL_Quit();
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// pkgi_update  — polls SDL events, translates keys, prepares next frame
+// ──────────────────────────────────────────────────────────────────────────────
+int pkgi_update(pkgi_input* input)
+{
+    uint32_t just_pressed = 0;
+
+    SDL_Event event;
+    while (SDL_PollEvent(&event))
+    {
+        switch (event.type)
+        {
+        case SDL_QUIT:
+            return 0;
+
+        case SDL_KEYDOWN:
+            // IME is active: handle only text-input keys, don't pass to
+            // the Vita button mapper so we don't accidentally trigger
+            // Cross / cancel etc. while the user is typing.
+            if (g_ime_active)
+            {
+                if (event.key.keysym.sym == SDLK_RETURN ||
+                    event.key.keysym.sym == SDLK_KP_ENTER)
+                {
+                    g_ime_confirmed = true;
+                    g_ime_active    = false;
+                    SDL_StopTextInput();
+                    SDL_SetWindowTitle(g_sdl_window, "PKGj Simulator");
+                }
+                else if (event.key.keysym.sym == SDLK_ESCAPE)
+                {
+                    g_ime_active = false;
+                    g_ime_confirmed = false;
+                    g_ime_input.clear();
+                    SDL_StopTextInput();
+                    SDL_SetWindowTitle(g_sdl_window, "PKGj Simulator");
+                }
+                else if (event.key.keysym.sym == SDLK_BACKSPACE &&
+                         !g_ime_input.empty())
+                {
+                    // Remove last UTF-8 character
+                    g_ime_input.pop_back();
+                    while (!g_ime_input.empty() &&
+                           (g_ime_input.back() & 0xC0) == 0x80)
+                        g_ime_input.pop_back();
+                }
+                break; // do NOT fall through to button mapper
+            }
+            if (!event.key.repeat)
+            {
+                uint32_t btn = sdl_key_to_button(event.key.keysym.sym);
+                if (btn)
+                {
+                    just_pressed  |= btn;
+                    g_current_down |= btn;
+                }
+            }
+            break;
+
+        case SDL_KEYUP:
+        {
+            uint32_t btn = sdl_key_to_button(event.key.keysym.sym);
+            if (btn) g_current_down &= ~btn;
+            break;
+        }
+
+        case SDL_TEXTINPUT:
+            if (g_ime_active)
+                g_ime_input += event.text.text;
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    uint32_t previous = input->down;
+    input->down    = g_current_down;
+    input->pressed = just_pressed;
+    input->active  = just_pressed;
+
+    if (input->down == previous)
+    {
+        if (g_button_frame_count >= 10)
+            input->active = input->down;
+        g_button_frame_count++;
+    }
+    else
+    {
+        g_button_frame_count = 0;
+    }
+
+    // Clear screen at start of frame
+    SDL_SetRenderDrawColor(g_sdl_renderer, 30, 30, 30, 255);
+    SDL_RenderClear(g_sdl_renderer);
+    // Reset clip so full-screen draws work
+    SDL_RenderSetClipRect(g_sdl_renderer, nullptr);
+
+    uint64_t now = SDL_GetTicks();
+    input->delta = (now - g_time_ms) * 1000; // microseconds
+    g_time_ms    = now;
+
+    return 1;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// pkgi_swap — present the rendered frame
+// ──────────────────────────────────────────────────────────────────────────────
+void pkgi_swap(void)
+{
+    SDL_RenderPresent(g_sdl_renderer);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Drawing primitives
+// ──────────────────────────────────────────────────────────────────────────────
+void pkgi_clip_set(int x, int y, int w, int h)
+{
+    g_clipping = true;
+    g_clip_rect = {x, y, w, h};
+    SDL_RenderSetClipRect(g_sdl_renderer, &g_clip_rect);
+}
+
+void pkgi_clip_remove(void)
+{
+    g_clipping = false;
+    SDL_RenderSetClipRect(g_sdl_renderer, nullptr);
+}
+
+void pkgi_draw_rect(int x, int y, int w, int h, uint32_t color)
+{
+    sdl_set_color(g_sdl_renderer, color);
+    const SDL_Rect r{x, y, w, h};
+    SDL_RenderFillRect(g_sdl_renderer, &r);
+}
+
+void pkgi_draw_text(int x, int y, uint32_t color, const char* text)
+{
+    if (!g_font || !text || !*text)
+        return;
+
+    SDL_Color c{
+        static_cast<Uint8>(color & 0xFF),
+        static_cast<Uint8>((color >> 8) & 0xFF),
+        static_cast<Uint8>((color >> 16) & 0xFF),
+        255};
+
+    SDL_Surface* surf = TTF_RenderUTF8_Blended(g_font, text, c);
+    if (!surf) return;
+
+    SDL_Texture* tex = SDL_CreateTextureFromSurface(g_sdl_renderer, surf);
+    SDL_FreeSurface(surf);
+    if (!tex) return;
+
+    int tw = 0, th = 0;
+    SDL_QueryTexture(tex, nullptr, nullptr, &tw, &th);
+
+    // vita.cpp draws at y+20 (font ascent offset) — replicate here
+    SDL_Rect dst{x, y + 2, tw, th};
+    SDL_RenderCopy(g_sdl_renderer, tex, nullptr, &dst);
+    SDL_DestroyTexture(tex);
+}
+
+int pkgi_text_width(const char* text)
+{
+    if (!g_font || !text || !*text) return 0;
+    int w = 0, h = 0;
+    TTF_SizeUTF8(g_font, text, &w, &h);
+    return w;
+}
+
+int pkgi_text_height(const char* text)
+{
+    (void)text;
+    if (!g_font) return 20;
+    return TTF_FontHeight(g_font);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Texture / PNG support
+// ──────────────────────────────────────────────────────────────────────────────
+pkgi_texture pkgi_load_png_raw(const void* data, uint32_t size)
+{
+    SDL_RWops* rw = SDL_RWFromConstMem(data, static_cast<int>(size));
+    if (!rw) return nullptr;
+    SDL_Surface* surf = IMG_LoadPNG_RW(rw);
+    SDL_RWclose(rw);
+    if (!surf) return nullptr;
+    SDL_Texture* tex = SDL_CreateTextureFromSurface(g_sdl_renderer, surf);
+    SDL_FreeSurface(surf);
+    return tex;
+}
+
+void pkgi_draw_texture(pkgi_texture texture, int x, int y)
+{
+    if (!texture) return;
+    SDL_Texture* tex = static_cast<SDL_Texture*>(texture);
+    int w = 0, h = 0;
+    SDL_QueryTexture(tex, nullptr, nullptr, &w, &h);
+    const SDL_Rect dst{x, y, w, h};
+    SDL_RenderCopy(g_sdl_renderer, tex, nullptr, &dst);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ImGui font texture creation (called from sim_main.cpp)
+// ──────────────────────────────────────────────────────────────────────────────
+SDL_Texture* sim_create_font_texture(const uint32_t* pixels, int w, int h)
+{
+    SDL_Texture* tex = SDL_CreateTexture(
+            g_sdl_renderer,
+            SDL_PIXELFORMAT_ABGR8888,
+            SDL_TEXTUREACCESS_STATIC,
+            w, h);
+    if (!tex)
+    {
+        fprintf(stderr, "[sim] SDL_CreateTexture (font) failed: %s\n",
+                SDL_GetError());
+        return nullptr;
+    }
+    SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
+    SDL_UpdateTexture(tex, nullptr, pixels,
+                      static_cast<int>(w * sizeof(uint32_t)));
+    return tex;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Button assignment
+// ──────────────────────────────────────────────────────────────────────────────
+int pkgi_ok_button(void)     { return g_ok_button;     }
+int pkgi_cancel_button(void) { return g_cancel_button; }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Dialog mutex (coarse lock used by dialog.cpp)
+// ──────────────────────────────────────────────────────────────────────────────
+void pkgi_dialog_lock(void)   { g_dialog_mutex.lock();   }
+void pkgi_dialog_unlock(void) { g_dialog_mutex.unlock(); }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IME / text-input dialog (maps to SDL text input on Linux)
+// ──────────────────────────────────────────────────────────────────────────────
+void pkgi_dialog_input_text(const char* title, const char* text)
+{
+    g_ime_title  = title  ? title  : "";
+    g_ime_input  = text   ? text   : "";
+    g_ime_active = true;
+    SDL_StartTextInput();
+    // Show title in window title bar as a hint
+    std::string wt =
+            fmt::format("PKGj Simulator — {} (type, Enter to confirm, Esc to cancel)",
+                        g_ime_title);
+    SDL_SetWindowTitle(g_sdl_window, wt.c_str());
+}
+
+int pkgi_dialog_input_update(void)
+{
+    // Returns 1 exactly once after the user confirms input with Enter.
+    // g_ime_confirmed is set inside pkgi_update's SDL_KEYDOWN handler.
+    if (g_ime_confirmed)
+    {
+        g_ime_confirmed = false;
+        return 1;
+    }
+    return 0;
+}
+
+// Called after pkgi_dialog_input_update returns 1 (see SDL KEYDOWN handler).
+// We expose a separate function that pkgi_update can call when detecting
+// SDLK_RETURN while g_ime_active; here we just provide the query function.
+void pkgi_dialog_input_get_text(char* text, uint32_t size)
+{
+    strncpy(text, g_ime_input.c_str(), size - 1);
+    text[size - 1] = '\0';
+    SDL_SetWindowTitle(g_sdl_window, "PKGj Simulator");
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Battery stubs (no battery on PC)
+// ──────────────────────────────────────────────────────────────────────────────
+int pkgi_battery_present(void)      { return 0; }
+int pkgi_bettery_get_level(void)    { return 100; }
+int pkgi_battery_is_low(void)       { return 0; }
+int pkgi_battery_is_charging(void)  { return 0; }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Filesystem helpers
+// ──────────────────────────────────────────────────────────────────────────────
+uint64_t pkgi_get_free_space(const char* path)
+{
+    struct statvfs sv;
+    if (statvfs(path[0] ? path : ".", &sv) != 0)
+        return 0;
+    return (uint64_t)sv.f_bfree * sv.f_bsize;
+}
+
+const char* pkgi_get_config_folder(void)
+{
+    static const char* folder = "pkgj";
+    // Ensure the folder exists
+    mkdir(folder, 0755);
+    return folder;
+}
+
+int pkgi_is_incomplete(const char* partition, const char* contentid)
+{
+    (void)partition;
+    return pkgi_file_exists(
+            fmt::format("pkgj/{}.resume", contentid).c_str());
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Process lock stubs (no shell on PC)
+// ──────────────────────────────────────────────────────────────────────────────
+void pkgi_lock_process(void)   {}
+void pkgi_unlock_process(void) {}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Threads (std::thread wrappers)
+// ──────────────────────────────────────────────────────────────────────────────
+void pkgi_start_thread(const char* name, pkgi_thread_entry* start)
+{
+    (void)name;
+    std::thread(start).detach();
+}
+
+void pkgi_sleep(uint32_t msec)
+{
+    SDL_Delay(msec);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// System version stub
+// ──────────────────────────────────────────────────────────────────────────────
+std::string pkgi_get_system_version()
+{
+    return "Linux Simulator";
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Module presence stub (always "not present" on PC)
+// ──────────────────────────────────────────────────────────────────────────────
+bool pkgi_is_module_present(const char*)
+{
+    return false;
+}

--- a/simulator/sim_file.cpp
+++ b/simulator/sim_file.cpp
@@ -1,0 +1,74 @@
+// sim_file.cpp
+// Provides POSIX implementations of file.hpp functions that are not already
+// present in simulator.cpp (which covers the basic I/O primitives).
+//
+// Functions provided here:
+//   pkgi_list_dir_contents  — list directory entries
+//   pkgi_get_size           — stat a file for its size
+//   pkgi_get_inode_type     — stat a path to classify it
+//   pkgi_append             — open a file in append mode
+
+#include "file.hpp"
+
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <stdexcept>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <vector>
+
+// ─────────────────────────────────────────────────────────────────────────────
+std::vector<std::string> pkgi_list_dir_contents(const std::string& path)
+{
+    std::vector<std::string> result;
+
+    DIR* d = opendir(path.c_str());
+    if (!d)
+        return result; // empty vector on missing/inaccessible directory
+
+    struct dirent* ent;
+    while ((ent = readdir(d)) != nullptr)
+    {
+        const std::string name = ent->d_name;
+        if (name == "." || name == "..")
+            continue;
+        result.push_back(name);
+    }
+    closedir(d);
+    return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+int64_t pkgi_get_size(const char* path)
+{
+    struct stat st;
+    if (stat(path, &st) != 0)
+        return -1;
+    return static_cast<int64_t>(st.st_size);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+InodeType pkgi_get_inode_type(const std::string& path)
+{
+    struct stat st;
+    if (stat(path.c_str(), &st) != 0)
+        return InodeType::NotExist;
+    if (S_ISDIR(st.st_mode))
+        return InodeType::Directory;
+    return InodeType::File;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Open (or create) a file for appending; returns a void* handle compatible
+// with pkgi_write / pkgi_close.
+void* pkgi_append(const char* path)
+{
+    int fd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0666);
+    if (fd < 0)
+        return nullptr;
+    return reinterpret_cast<void*>(static_cast<intptr_t>(fd));
+}

--- a/simulator/update_stub.cpp
+++ b/simulator/update_stub.cpp
@@ -1,0 +1,10 @@
+// update_stub.cpp
+// Stub for update.hpp — automatic version checking is not needed in the
+// Linux simulator.
+
+#include "update.hpp"
+
+void start_update_thread()
+{
+    // no-op in simulator
+}

--- a/simulator/vitahttp_stub.cpp
+++ b/simulator/vitahttp_stub.cpp
@@ -1,0 +1,241 @@
+// vitahttp_stub.cpp
+// Real HTTP implementation for the pkgj Linux simulator using libcurl.
+//
+// start()  → launches a background thread that runs curl_easy_perform();
+//            blocks until response headers are received so that get_status()
+//            and get_length() are valid immediately after start() returns.
+// read()   → drains a shared deque filled by the curl write callback;
+//            blocks until data or end-of-transfer.
+// abort()  → sets a flag; the write callback returns 0 which causes curl to
+//            cancel the transfer.
+
+#include "vitahttp.hpp"
+
+#include "log.hpp"
+
+#include <curl/curl.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+struct pkgi_http
+{
+    CURL* easy = nullptr;
+    std::thread thread;
+
+    std::atomic<bool> aborted{false};
+
+    // Set once headers are received; start() waits on this.
+    bool headers_ready = false;
+    long status_code = 0;
+    curl_off_t content_length = -1;
+    std::string error_msg;
+
+    // Streaming body buffer shared between curl thread and read().
+    std::deque<uint8_t> buf;
+    bool transfer_done = false;
+
+    std::mutex mtx;
+    std::condition_variable cv;
+};
+
+// ---------------------------------------------------------------------------
+// Curl callbacks
+// ---------------------------------------------------------------------------
+
+// Called once per header line.
+static size_t header_cb(char* ptr, size_t size, size_t nmemb, void* userdata)
+{
+    auto* h = static_cast<pkgi_http*>(userdata);
+    const size_t total = size * nmemb;
+    const std::string line(ptr, total);
+
+    // "HTTP/1.x NNN …" or "HTTP/2 NNN …"
+    if (line.rfind("HTTP/", 0) == 0)
+    {
+        const auto sp = line.find(' ');
+        if (sp != std::string::npos)
+            h->status_code = std::stol(line.substr(sp + 1));
+    }
+    else if (line.rfind("Content-Length:", 0) == 0)
+    {
+        const auto sp = line.find(':');
+        if (sp != std::string::npos)
+            h->content_length =
+                    static_cast<curl_off_t>(std::stoll(line.substr(sp + 1)));
+    }
+
+    // Blank line = end of headers → wake start()
+    if (line == "\r\n" || line == "\n")
+    {
+        std::lock_guard<std::mutex> lk(h->mtx);
+        h->headers_ready = true;
+        h->cv.notify_all();
+    }
+
+    return total;
+}
+
+// Called repeatedly with body data.
+static size_t write_cb(char* ptr, size_t size, size_t nmemb, void* userdata)
+{
+    auto* h = static_cast<pkgi_http*>(userdata);
+    const size_t total = size * nmemb;
+
+    if (h->aborted)
+        return 0; // returning 0 makes curl abort with CURLE_WRITE_ERROR
+
+    // Back-pressure: don't buffer more than 8 MB at once.
+    {
+        std::unique_lock<std::mutex> lk(h->mtx);
+        h->cv.wait(lk, [h] {
+            return h->aborted.load() || h->buf.size() < 8 * 1024 * 1024;
+        });
+        if (h->aborted)
+            return 0;
+
+        h->buf.insert(h->buf.end(), (uint8_t*)ptr, (uint8_t*)ptr + total);
+    }
+    h->cv.notify_all();
+    return total;
+}
+
+// ---------------------------------------------------------------------------
+// VitaHttp
+// ---------------------------------------------------------------------------
+
+VitaHttp::~VitaHttp()
+{
+    if (_http)
+    {
+        _http->aborted = true;
+        _http->cv.notify_all();
+        if (_http->thread.joinable())
+            _http->thread.join();
+        curl_easy_cleanup(_http->easy);
+        delete _http;
+        _http = nullptr;
+    }
+}
+
+void VitaHttp::start(const std::string& url, uint64_t offset)
+{
+    LOGF("VitaHttp::start {}", url);
+
+    auto* h = new pkgi_http();
+    h->easy = curl_easy_init();
+    if (!h->easy)
+    {
+        delete h;
+        throw HttpError("curl_easy_init() failed");
+    }
+
+    curl_easy_setopt(h->easy, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(h->easy, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(h->easy, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(h->easy, CURLOPT_SSL_VERIFYHOST, 2L);
+    curl_easy_setopt(h->easy, CURLOPT_USERAGENT, "pkgj-sim/1.0");
+    curl_easy_setopt(h->easy, CURLOPT_HEADERFUNCTION, header_cb);
+    curl_easy_setopt(h->easy, CURLOPT_HEADERDATA, h);
+    curl_easy_setopt(h->easy, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(h->easy, CURLOPT_WRITEDATA, h);
+
+    if (offset > 0)
+    {
+        const std::string range = std::to_string(offset) + "-";
+        curl_easy_setopt(h->easy, CURLOPT_RANGE, range.c_str());
+    }
+
+    // Run the transfer in a background thread.
+    h->thread = std::thread([h] {
+        const CURLcode rc = curl_easy_perform(h->easy);
+        if (rc != CURLE_OK && rc != CURLE_WRITE_ERROR)
+        {
+            // CURLE_WRITE_ERROR is expected when abort() returns 0.
+            std::lock_guard<std::mutex> lk(h->mtx);
+            h->error_msg = curl_easy_strerror(rc);
+        }
+        // Mark done and ensure start() can unblock even if no blank header
+        // line was seen (e.g. on error).
+        {
+            std::lock_guard<std::mutex> lk(h->mtx);
+            h->headers_ready = true;
+            h->transfer_done = true;
+        }
+        h->cv.notify_all();
+    });
+
+    // Block until headers arrive (or transfer ends early on error).
+    {
+        std::unique_lock<std::mutex> lk(h->mtx);
+        h->cv.wait(lk, [h] { return h->headers_ready; });
+        if (!h->error_msg.empty())
+        {
+            // Thread will end on its own; join and clean up.
+            lk.unlock();
+            h->thread.join();
+            curl_easy_cleanup(h->easy);
+            const std::string msg = h->error_msg;
+            delete h;
+            throw HttpError(msg);
+        }
+    }
+
+    _http = h;
+}
+
+int64_t VitaHttp::read(uint8_t* buffer, uint64_t size)
+{
+    std::unique_lock<std::mutex> lk(_http->mtx);
+    _http->cv.wait(lk, [this] {
+        return !_http->buf.empty() || _http->transfer_done ||
+               _http->aborted;
+    });
+
+    if (_http->buf.empty())
+        return 0; // EOF
+
+    const size_t n = std::min((size_t)size, _http->buf.size());
+    std::copy(_http->buf.begin(), _http->buf.begin() + n, buffer);
+    _http->buf.erase(_http->buf.begin(), _http->buf.begin() + n);
+    lk.unlock();
+    _http->cv.notify_all(); // release back-pressure on write_cb
+    return static_cast<int64_t>(n);
+}
+
+void VitaHttp::abort()
+{
+    if (_http)
+    {
+        _http->aborted = true;
+        _http->cv.notify_all();
+    }
+}
+
+int VitaHttp::get_status()
+{
+    return _http ? static_cast<int>(_http->status_code) : 0;
+}
+
+int64_t VitaHttp::get_length()
+{
+    return _http ? static_cast<int64_t>(_http->content_length) : -1;
+}
+
+VitaHttp::operator bool() const
+{
+    return _http != nullptr;
+}
+
+void VitaHttp::check_status()
+{
+    // Unused in simulator; status is available immediately after start().
+}

--- a/src/annotationdb.cpp
+++ b/src/annotationdb.cpp
@@ -1,0 +1,109 @@
+#include "annotationdb.hpp"
+
+#include "log.hpp"
+
+#include <fmt/format.h>
+#include <stdexcept>
+
+AnnotationDatabase::AnnotationDatabase(const std::string& dbPath)
+    : _dbPath(dbPath)
+{
+    open();
+}
+
+void AnnotationDatabase::open()
+{
+    LOGF("Opening annotation database: {}", _dbPath);
+
+    sqlite3* raw = nullptr;
+    if (sqlite3_open(_dbPath.c_str(), &raw) != SQLITE_OK)
+        throw std::runtime_error(
+                fmt::format("can't open annotation db: {}", _dbPath));
+    _db.reset(raw);
+
+    // Create table if it doesn't exist yet
+    const char* create_sql =
+        "CREATE TABLE IF NOT EXISTS annotations ("
+        "    titleid TEXT PRIMARY KEY NOT NULL,"
+        "    flag    INTEGER NOT NULL DEFAULT 0,"
+        "    comment TEXT    NOT NULL DEFAULT ''"
+        ");";
+
+    char* errmsg = nullptr;
+    if (sqlite3_exec(_db.get(), create_sql, nullptr, nullptr, &errmsg) !=
+        SQLITE_OK)
+    {
+        std::string msg = errmsg ? errmsg : "unknown error";
+        sqlite3_free(errmsg);
+        throw std::runtime_error(
+                fmt::format("can't create annotations table: {}", msg));
+    }
+}
+
+UserAnnotation AnnotationDatabase::get(const std::string& titleid) const
+{
+    const char* sql =
+        "SELECT flag, comment FROM annotations WHERE titleid = ?;";
+
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(_db.get(), sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return {};
+
+    sqlite3_bind_text(stmt, 1, titleid.c_str(), -1, SQLITE_TRANSIENT);
+
+    UserAnnotation ann;
+    if (sqlite3_step(stmt) == SQLITE_ROW)
+    {
+        ann.flag    = static_cast<UserFlag>(sqlite3_column_int(stmt, 0));
+        const char* txt = reinterpret_cast<const char*>(
+                sqlite3_column_text(stmt, 1));
+        ann.comment = txt ? txt : "";
+    }
+    sqlite3_finalize(stmt);
+    return ann;
+}
+
+void AnnotationDatabase::set(const std::string& titleid,
+                             const UserAnnotation& ann)
+{
+    // If nothing meaningful is stored, just delete the row
+    if (ann.flag == UserFlag::None && ann.comment.empty())
+    {
+        remove(titleid);
+        return;
+    }
+
+    const char* sql =
+        "INSERT OR REPLACE INTO annotations (titleid, flag, comment)"
+        " VALUES (?, ?, ?);";
+
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(_db.get(), sql, -1, &stmt, nullptr) != SQLITE_OK)
+        throw std::runtime_error(
+                fmt::format("annotation insert prepare failed: {}",
+                            sqlite3_errmsg(_db.get())));
+
+    sqlite3_bind_text(stmt, 1, titleid.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int (stmt, 2, static_cast<int>(ann.flag));
+    sqlite3_bind_text(stmt, 3, ann.comment.c_str(), -1, SQLITE_TRANSIENT);
+
+    const int rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE)
+        throw std::runtime_error(
+                fmt::format("annotation insert failed: {}",
+                            sqlite3_errmsg(_db.get())));
+}
+
+void AnnotationDatabase::remove(const std::string& titleid)
+{
+    const char* sql = "DELETE FROM annotations WHERE titleid = ?;";
+
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(_db.get(), sql, -1, &stmt, nullptr) != SQLITE_OK)
+        return;
+
+    sqlite3_bind_text(stmt, 1, titleid.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+}

--- a/src/annotationdb.hpp
+++ b/src/annotationdb.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "sqlite.hpp"
+
+#include <fmt/format.h>
+#include <string>
+
+// Symbols shown in the title list next to a flagged item.
+// Keep them in the ASCII-compatible range or use UTF-8 sequences already
+// known to the Vita font (ltn0.pvf / jpn0.pvf).
+enum class UserFlag : int
+{
+    None        = 0,
+    Favorite    = 1,  // [*] star
+    VeryGood    = 2,  // [+] thumbs up
+    Good        = 3,  // [+]
+    Bad         = 4,  // [-]
+    VeryBad     = 5,  // [--]
+    Broken      = 6,  // [X] broken / doesn't work
+    Completed   = 7,  // [/] finished / platinumed
+    WantToPlay  = 8,  // [?] wishlist
+};
+
+static constexpr int UserFlagCount = 9; // including None
+
+// Short ASCII symbols shown inline in the title list
+inline const char* user_flag_symbol(UserFlag f)
+{
+    switch (f)
+    {
+    case UserFlag::None:       return "";
+    case UserFlag::Favorite:   return "[*]";
+    case UserFlag::VeryGood:   return "[++]";
+    case UserFlag::Good:       return "[+]";
+    case UserFlag::Bad:        return "[-]";
+    case UserFlag::VeryBad:    return "[--]";
+    case UserFlag::Broken:     return "[X]";
+    case UserFlag::Completed:  return "[/]";
+    case UserFlag::WantToPlay: return "[?]";
+    }
+    return "";
+}
+
+// Human-readable label used in the GameView flag picker
+inline const char* user_flag_label(UserFlag f)
+{
+    switch (f)
+    {
+    case UserFlag::None:       return "None";
+    case UserFlag::Favorite:   return "[*]  Favorite";
+    case UserFlag::VeryGood:   return "[++] Very Good";
+    case UserFlag::Good:       return "[+]  Good";
+    case UserFlag::Bad:        return "[-]  Bad";
+    case UserFlag::VeryBad:    return "[--] Very Bad";
+    case UserFlag::Broken:     return "[X]  Broken";
+    case UserFlag::Completed:  return "[/]  Completed";
+    case UserFlag::WantToPlay: return "[?]  Want to Play";
+    }
+    return "None";
+}
+
+struct UserAnnotation
+{
+    UserFlag    flag    = UserFlag::None;
+    std::string comment;
+};
+
+class AnnotationDatabase
+{
+public:
+    explicit AnnotationDatabase(const std::string& dbPath);
+
+    // Returns a default-constructed annotation if titleid is not found
+    UserAnnotation get(const std::string& titleid) const;
+
+    // Inserts or replaces the annotation for titleid.
+    // If flag==None and comment is empty the row is deleted instead.
+    void set(const std::string& titleid, const UserAnnotation& ann);
+
+    void remove(const std::string& titleid);
+
+private:
+    SqlitePtr _db;
+    std::string _dbPath;
+
+    void open();
+};

--- a/src/browserview.cpp
+++ b/src/browserview.cpp
@@ -1,0 +1,264 @@
+#include "browserview.hpp"
+
+extern "C"
+{
+#include "style.h"
+}
+#include "config.hpp"
+#include "pkgi.hpp"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+
+// ---------------------------------------------------------------------------
+// Build the static category tree.
+//
+// ── How to add the future "group by initial" layer ──────────────────────────
+// Replace any leaf node (mode set, children empty) with an internal node
+// (mode absent, children non-empty) whose children are leaves that each carry
+// both `mode` and a non-empty `group_filter`.  The onModeSelected callback
+// will receive the group_filter and can apply it as a prefix search to the
+// loaded game list.
+//
+// Example — expanding "PlayStation Vita > Games" into lettered groups:
+//
+//   { "PlayStation Vita", std::nullopt, {
+//       { "Games", std::nullopt, {              // <── now internal
+//           { "#",   ModeGames, {}, "0123456789" },
+//           { "A-D", ModeGames, {}, "ABCD" },
+//           { "E-H", ModeGames, {}, "EFGH" },
+//           { "I-L", ModeGames, {}, "IJKL" },
+//           { "M-P", ModeGames, {}, "MNOP" },
+//           { "Q-T", ModeGames, {}, "QRST" },
+//           { "U-Z", ModeGames, {}, "UVWXYZ" },
+//       }, "" },
+//       ...
+//   }, "" },
+// ---------------------------------------------------------------------------
+static std::vector<BrowseNode> build_tree(const Config& config)
+{
+    auto root = std::vector<BrowseNode>{
+        { "PSVITA Games",  ModeGames,    {}, "", "" },
+        { "PSVITA DLCs",   ModeDlcs,     {}, "", "" },
+        { "PSVITA Demos",  ModeDemos,    {}, "", "" },
+        { "PSP Games",     ModePspGames, {}, "", "" },
+        { "PSP DLCs",      ModePspDlcs,  {}, "", "" },
+        { "PSONE Games",   ModePsxGames, {}, "", "" },
+        { "PSM Games",     ModePsmGames, {}, "", "" },
+        { "Themes",        ModeThemes,   {}, "", "" },
+    };
+
+    int custom_number = 1;
+    for (const auto& entry : config.custom_entries)
+    {
+        if (entry.name.empty() || entry.url.empty())
+            continue;
+        root.push_back({
+                fmt::format("Custom {}", custom_number++),
+                std::nullopt,
+                {},
+                "",
+                entry.url,
+        });
+    }
+
+    return root;
+}
+
+// ---------------------------------------------------------------------------
+
+BrowseView::BrowseView(
+        const Config& config,
+        std::function<void(const BrowseNode&)> onNodeSelected)
+    : _root(build_tree(config))
+    , _onNodeSelected(std::move(onNodeSelected))
+{
+}
+
+const std::vector<BrowseNode>& BrowseView::current_nodes() const
+{
+    const std::vector<BrowseNode>* nodes = &_root;
+    for (const auto& lvl : _stack)
+        nodes = &(*nodes)[lvl.selected].children;
+    return *nodes;
+}
+
+void BrowseView::enter_child()
+{
+    _stack.push_back({ _selected, _first });
+    _selected = 0;
+    _first    = 0;
+}
+
+bool BrowseView::go_back()
+{
+    if (_stack.empty())
+        return false;
+    const auto prev = _stack.back();
+    _stack.pop_back();
+    _selected = prev.selected;
+    _first    = prev.first;
+    return true;
+}
+
+bool BrowseView::update(const pkgi_input& input)
+{
+    const auto& nodes  = current_nodes();
+    const size_t count = nodes.size();
+
+    const int font_h = pkgi_text_height("M");
+    const size_t max_vis = static_cast<size_t>(std::max(
+            1,
+            (VITA_HEIGHT - 2 * (font_h + PKGI_MAIN_HLINE_EXTRA)) /
+                    (font_h + PKGI_MAIN_ROW_PADDING)));
+
+    if (count == 0)
+        return true;
+
+    if (input.active & PKGI_BUTTON_UP)
+    {
+        if (_selected > 0)
+        {
+            --_selected;
+            if (_selected < _first)
+                _first = _selected;
+        }
+        else
+        {
+            _selected = count - 1;
+            _first    = count > max_vis ? count - max_vis : 0;
+        }
+    }
+
+    if (input.active & PKGI_BUTTON_DOWN)
+    {
+        if (_selected + 1 < count)
+        {
+            ++_selected;
+            if (_selected >= _first + max_vis)
+                _first = _selected - max_vis + 1;
+        }
+        else
+        {
+            _selected = 0;
+            _first    = 0;
+        }
+    }
+
+    if (input.pressed & pkgi_ok_button())
+    {
+        const BrowseNode& node = nodes[_selected];
+        if (!node.children.empty())
+            enter_child();
+        else
+            _onNodeSelected(node);
+        return true;
+    }
+
+    if (input.pressed & pkgi_cancel_button())
+        return go_back();  // false at root → caller transitions away
+
+    return true;
+}
+
+void BrowseView::render() const
+{
+    const auto& nodes  = current_nodes();
+    const size_t count = nodes.size();
+    const int font_h   = pkgi_text_height("M");
+
+    // ── Breadcrumb header ────────────────────────────────────────────────────
+    std::string breadcrumb = "Home";
+    {
+        const std::vector<BrowseNode>* cur = &_root;
+        bool is_first = true;
+        for (const auto& lvl : _stack)
+        {
+            if (is_first) { breadcrumb.clear(); is_first = false; }
+            else          breadcrumb += " > ";
+            breadcrumb += (*cur)[lvl.selected].label;
+            cur = &(*cur)[lvl.selected].children;
+        }
+    }
+
+    const std::string header = fmt::format("Browse: {}", breadcrumb);
+    pkgi_draw_text(
+            (VITA_WIDTH - pkgi_text_width(header.c_str())) / 2,
+            0,
+            PKGI_COLOR_TEXT_HEAD,
+            header.c_str());
+
+    pkgi_draw_rect(
+            0, font_h, VITA_WIDTH, PKGI_MAIN_HLINE_HEIGHT, PKGI_COLOR_HLINE);
+
+    // ── Compute list bounds (leave room for footer hint) ─────────────────────
+    const int hint_area = font_h + PKGI_MAIN_HLINE_EXTRA;
+    const int list_top  = font_h + PKGI_MAIN_HLINE_EXTRA;
+    const int list_bot  = VITA_HEIGHT - hint_area;
+    const size_t max_vis = static_cast<size_t>(std::max(
+            1, (list_bot - list_top) / (font_h + PKGI_MAIN_ROW_PADDING)));
+
+    // ── Item list ─────────────────────────────────────────────────────────────
+    int y = list_top;
+    for (size_t i = _first; i < count && i < _first + max_vis; ++i)
+    {
+        const bool sel         = (i == _selected);
+        const BrowseNode& node = nodes[i];
+
+        if (sel)
+            pkgi_draw_rect(
+                    0, y, VITA_WIDTH,
+                    font_h + PKGI_MAIN_ROW_PADDING - 1,
+                    PKGI_COLOR_SELECTED_BACKGROUND);
+
+        // ► prefix for nodes that can be entered (have children)
+        const char* arrow = node.children.empty()
+                          ? "   "
+                          : "\xe2\x96\xba  "; // ►
+        const std::string label = fmt::format("{}{}", arrow, node.label);
+
+        pkgi_draw_text(
+                PKGI_MAIN_COLUMN_PADDING, y,
+                sel ? PKGI_COLOR_TEXT_SELECTED : PKGI_COLOR_TEXT,
+                label.c_str());
+
+        y += font_h + PKGI_MAIN_ROW_PADDING;
+    }
+
+    // ── Scroll bar ───────────────────────────────────────────────────────────
+    if (count > max_vis)
+    {
+        const int avail = list_bot - list_top;
+        const int bar_h = std::max(
+                PKGI_MAIN_SCROLL_MIN_HEIGHT,
+                static_cast<int>(max_vis * avail / count));
+        const int bar_y = static_cast<int>(
+                _first * static_cast<size_t>(avail - bar_h) /
+                (count - max_vis));
+
+        pkgi_draw_rect(
+                VITA_WIDTH - PKGI_MAIN_SCROLL_WIDTH - 1,
+                list_top + bar_y,
+                PKGI_MAIN_SCROLL_WIDTH,
+                bar_h,
+                PKGI_COLOR_SCROLL_BAR);
+    }
+
+    // ── Footer hint ──────────────────────────────────────────────────────────
+    pkgi_draw_rect(
+            0, list_bot, VITA_WIDTH, PKGI_MAIN_HLINE_HEIGHT, PKGI_COLOR_HLINE);
+
+    char hint[128];
+    const char* ok_str =
+            pkgi_ok_button() == PKGI_BUTTON_X ? PKGI_UTF8_X : PKGI_UTF8_O;
+    const char* cancel_str =
+            pkgi_cancel_button() == PKGI_BUTTON_O ? PKGI_UTF8_O : PKGI_UTF8_X;
+    pkgi_snprintf(
+            hint, sizeof(hint), "%s Select  %s Back", ok_str, cancel_str);
+    pkgi_draw_text(
+            (VITA_WIDTH - pkgi_text_width(hint)) / 2,
+            list_bot + PKGI_MAIN_HLINE_HEIGHT,
+            PKGI_COLOR_TEXT_TAIL,
+            hint);
+}

--- a/src/browserview.hpp
+++ b/src/browserview.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "db.hpp"
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+typedef struct Config Config;
+struct pkgi_input;
+
+// ---------------------------------------------------------------------------
+// BrowseNode — one entry in the category hierarchy
+//
+// Intended tree layout (layers):
+//   Layer 0  Family      PlayStation Vita, PSP, PS1, PSM
+//   Layer 1  Content     Games, DLCs, Demos, Themes …
+//   Layer 2  (future)    Groups by initial — Numbers, A-D, E-G, H-K …
+//   Layer 3  (future)    game list via pkgi_set_mode + group_filter applied
+//
+// A node is a LEAF when `mode` has a value and `children` is empty.
+// An internal node has `children` non-empty and no `mode`.
+//
+// To add the future "group by initial" layer, replace a leaf node that
+// currently has `mode` set with an internal node that has child leaves.
+// Each child leaf carries both `mode` and a non-empty `group_filter` that
+// the onModeSelected callback will use to filter the game list.
+// ---------------------------------------------------------------------------
+struct BrowseNode
+{
+    std::string             label;
+    std::optional<Mode>     mode;       // leaf: the Mode this entry activates
+    std::vector<BrowseNode> children;   // non-empty → internal node
+
+    // Future "group by initial" use: when this leaf node is confirmed, this
+    // value is forwarded to onModeSelected so the game-list layer can apply
+    // it as a prefix filter (e.g. "A-D" to show titles starting A through D).
+    // Empty means no additional filter.
+    std::string group_filter;
+
+    // Custom lists come from config.txt and point directly to a TSV file.
+    // They do not use a built-in Mode and therefore need a custom handler.
+    std::string custom_tsv_url;
+};
+
+// ---------------------------------------------------------------------------
+// BrowseView — renders the current tree level and handles controller input.
+//
+// Usage (each frame):
+//   if (!browse_view->update(input)) { /* user backed out at root */ }
+//   browse_view->render();
+//
+// onModeSelected receives the chosen Mode and an optional group_filter string.
+// ---------------------------------------------------------------------------
+class BrowseView
+{
+public:
+    explicit BrowseView(
+            const Config& config,
+            std::function<void(const BrowseNode&)> onNodeSelected);
+
+    // Process one frame of input.
+    // Returns false when the user presses Back at the root level.
+    bool update(const pkgi_input& input);
+
+    void render() const;
+
+private:
+    std::vector<BrowseNode> _root;
+
+    // Stack tracking the path taken so far (enables back-navigation +
+    // breadcrumb rendering).  One entry per level entered.
+    struct LevelState { size_t selected; size_t first; };
+    std::vector<LevelState> _stack;
+
+    size_t _selected = 0;
+    size_t _first    = 0;
+
+    std::function<void(const BrowseNode&)> _onNodeSelected;
+
+    const std::vector<BrowseNode>& current_nodes() const;
+    void enter_child();
+    bool go_back();  // returns false if already at root
+};

--- a/src/comppackdb.cpp
+++ b/src/comppackdb.cpp
@@ -23,7 +23,7 @@ CompPackDatabase::CompPackDatabase(std::string const& dbPath) : _dbPath(dbPath)
 
 void CompPackDatabase::reopen()
 {
-    LOG("opening database %s", _dbPath.c_str());
+    LOG("Opening comppack database: %s", _dbPath.c_str());
     sqlite3* db;
     SQLITE_CHECK(sqlite3_open(_dbPath.c_str(), &db), "can't open database");
     _sqliteDb.reset(db);
@@ -46,7 +46,7 @@ void CompPackDatabase::reopen()
     }
     catch (const std::exception& e)
     {
-        LOG("%s. Trying migration.", e.what());
+        LOG_WARN("Schema migration needed: %s", e.what());
         SQLITE_EXEC(
                 _sqliteDb,
                 R"(DROP TABLE IF EXISTS entries)",
@@ -114,7 +114,7 @@ void CompPackDatabase::parse_entries(std::string& db_data)
             auto err = sqlite3_exec(
                     _sqliteDb.get(), "ROLLBACK", nullptr, nullptr, &errmsg);
             if (err != SQLITE_OK)
-                LOG("sqlite error: %s", errmsg);
+                LOG_ERR("SQLite error during comppack save: %s", errmsg);
         }
     };
 
@@ -189,7 +189,7 @@ void CompPackDatabase::update(Http* http, const std::string& update_url)
     if (update_url.empty())
         throw std::runtime_error("no comp pack url");
 
-    LOGF("loading comp pack list from {}", update_url);
+    LOGF("Fetching comppack list from: {}", update_url);
 
     http->start(update_url, 0);
 
@@ -213,12 +213,12 @@ void CompPackDatabase::update(Http* http, const std::string& update_url)
         throw std::runtime_error(
                 "comp pack list is empty... check for newer pkgj version");
 
-    LOG("parsing items");
+    LOG("Parsing comppack list");
 
     db_data.resize(db_size);
     parse_entries(db_data);
 
-    LOG("finished parsing");
+    LOG("Comppack list parsed successfully");
 }
 
 std::optional<CompPackDatabase::Item> CompPackDatabase::get(
@@ -228,7 +228,7 @@ std::optional<CompPackDatabase::Item> CompPackDatabase::get(
     // after the app is suspended, all further query will return disk I/O error
     reopen();
 
-    LOG("reloading database");
+    LOG("Reloading comppack database");
 
     sqlite3_stmt* stmt;
     SQLITE_CHECK(

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdlib>
 
+#include <algorithm>
+
 #include <fmt/format.h>
 
 #include "file.hpp"
@@ -166,6 +168,73 @@ static DbFilter parse_filter(char* value, uint32_t filter)
     return static_cast<DbFilter>(result);
 }
 
+static int parse_custom_index(const char* key)
+{
+    if (pkgi_stricmp(key, "custom1") == 0)
+        return 0;
+    if (pkgi_stricmp(key, "custom2") == 0)
+        return 1;
+    if (pkgi_stricmp(key, "custom3") == 0)
+        return 2;
+    if (pkgi_stricmp(key, "custom4") == 0)
+        return 3;
+    if (pkgi_stricmp(key, "custom5") == 0)
+        return 4;
+    return -1;
+}
+
+static char* skipline(char* text, char* end)
+{
+    while (text < end && *text != '\n' && *text != '\r')
+        text++;
+    while (text < end && (*text == '\n' || *text == '\r'))
+        text++;
+    return text;
+}
+
+static void parse_custom_entry(
+        char* value,
+        char* end,
+        CustomConfigEntry* entry)
+{
+    entry->name.clear();
+    entry->url.clear();
+
+    value = skipws(value, end);
+    if (value == end || *value != '"')
+        return;
+
+    ++value;
+    char* name_start = value;
+    while (value < end && *value != '"' && *value != '\n' && *value != '\r')
+        value++;
+    if (value == end || *value != '"')
+        return;
+
+    *value++ = 0;
+    entry->name = name_start;
+
+    value = skipws(value, end);
+    if (value == end || *value == '\n' || *value == '\r')
+    {
+        entry->name.clear();
+        return;
+    }
+
+    char* url_start = value;
+    while (value < end && *value != '\n' && *value != '\r')
+        value++;
+
+    char* url_end = value;
+    while (url_end > url_start && (url_end[-1] == ' ' || url_end[-1] == '\t'))
+        --url_end;
+    *url_end = 0;
+
+    entry->url = url_start;
+    if (entry->url.empty())
+        entry->name.clear();
+}
+
 Config pkgi_load_config()
 {
     try
@@ -217,6 +286,18 @@ Config pkgi_load_config()
             text = skipws(text, end);
             if (text == end)
                 break;
+
+            const int custom_index = parse_custom_index(key);
+            if (custom_index >= 0)
+            {
+                char* line_end = text;
+                while (line_end < end && *line_end != '\n' && *line_end != '\r')
+                    line_end++;
+                parse_custom_entry(
+                        text, line_end, &config.custom_entries[custom_index]);
+                text = skipline(line_end, end);
+                continue;
+            }
 
             const auto value = text;
 
@@ -325,6 +406,19 @@ void pkgi_save_config(const Config& config)
     SAVE_CONF("url_psp_dlcs", psp_dlcs_url, default_psp_dlcs_url)
     SAVE_CONF("url_comppack", comppack_url, default_comppack_url)
 #undef SAVE_CONF
+    for (size_t i = 0; i < config.custom_entries.size(); i++)
+    {
+        const auto& entry = config.custom_entries[i];
+        if (entry.name.empty() || entry.url.empty())
+            continue;
+        len += pkgi_snprintf(
+                data + len,
+                sizeof(data) - len,
+                "custom%u \"%s\" %s\n",
+                static_cast<unsigned>(i + 1),
+                entry.name.c_str(),
+                entry.url.c_str());
+    }
     if (!config.thumbnail_url.empty())
         len += pkgi_snprintf(
                 data + len,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -240,7 +240,7 @@ Config pkgi_load_config()
     try
     {
         Config config{};
-        config.no_version_check = 1;  // fork: update URL points to upstream
+        config.no_version_check = 0;  // update check enabled: points to toaster-code/pkgj
 
         config.games_url = default_psv_games_url;
         config.dlcs_url = default_psv_dlcs_url;
@@ -342,7 +342,7 @@ Config pkgi_load_config()
             else if (pkgi_stricmp(key, "filter") == 0)
                 config.filter = parse_filter(value, DbFilterAll);
             else if (pkgi_stricmp(key, "no_version_check") == 0)
-                config.no_version_check = 1;
+                config.no_version_check = (pkgi_stricmp(value, "0") != 0);
             else if (pkgi_stricmp(key, "install_psp_psx_location") == 0)
                 config.install_psp_psx_location = value;
         }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,7 @@
 #include "config.hpp"
 
+#include <cstdlib>
+
 #include <fmt/format.h>
 
 #include "file.hpp"
@@ -169,6 +171,7 @@ Config pkgi_load_config()
     try
     {
         Config config{};
+        config.no_version_check = 1;  // fork: update URL points to upstream
 
         config.games_url = default_psv_games_url;
         config.dlcs_url = default_psv_dlcs_url;
@@ -179,6 +182,9 @@ Config pkgi_load_config()
         config.psp_games_url = default_psp_games_url;
         config.psp_dlcs_url = default_psp_dlcs_url;
         config.comppack_url = default_comppack_url;
+        config.thumbnail_url = "";
+        config.thumbnail_folder = "";
+        config.thumbnail_size = 2;
         config.sort = SortByName;
         config.order = SortAscending;
         config.filter = DbFilterAll;
@@ -186,7 +192,7 @@ Config pkgi_load_config()
 
         auto const path =
                 fmt::format("{}/config.txt", pkgi_get_config_folder());
-        LOGF("config location: {}", path);
+        LOGF("Config file path: {}", path);
 
         if (!pkgi_file_exists(path))
             return config;
@@ -194,7 +200,7 @@ Config pkgi_load_config()
         auto data = pkgi_load(path);
         data.push_back('\n');
 
-        LOG("config.txt loaded, parsing");
+        LOG("Parsing config.txt");
         auto text = reinterpret_cast<char*>(data.data());
         const auto end = text + data.size();
 
@@ -241,6 +247,13 @@ Config pkgi_load_config()
                 config.psp_dlcs_url = value;
             else if (pkgi_stricmp(key, "url_comppack") == 0)
                 config.comppack_url = value;
+            else if (pkgi_stricmp(key, "thumbnail_url") == 0)
+                config.thumbnail_url = value;
+            else if (pkgi_stricmp(key, "thumbnail_folder") == 0)
+                config.thumbnail_folder = value;
+            else if (pkgi_stricmp(key, "thumbnail_size") == 0)
+                config.thumbnail_size = static_cast<int>(
+                        std::strtol(value, nullptr, 10));
             else if (pkgi_stricmp(key, "sort") == 0)
                 config.sort = parse_sort(value, SortByName);
             else if (pkgi_stricmp(key, "order") == 0)
@@ -249,8 +262,6 @@ Config pkgi_load_config()
                 config.filter = parse_filter(value, DbFilterAll);
             else if (pkgi_stricmp(key, "no_version_check") == 0)
                 config.no_version_check = 1;
-            else if (pkgi_stricmp(key, "install_psp_as_pbp") == 0)
-                config.install_psp_as_pbp = 1;
             else if (pkgi_stricmp(key, "install_psp_psx_location") == 0)
                 config.install_psp_psx_location = value;
         }
@@ -314,6 +325,23 @@ void pkgi_save_config(const Config& config)
     SAVE_CONF("url_psp_dlcs", psp_dlcs_url, default_psp_dlcs_url)
     SAVE_CONF("url_comppack", comppack_url, default_comppack_url)
 #undef SAVE_CONF
+    if (!config.thumbnail_url.empty())
+        len += pkgi_snprintf(
+                data + len,
+                sizeof(data) - len,
+                "thumbnail_url %s\n",
+                config.thumbnail_url.c_str());
+    if (!config.thumbnail_folder.empty())
+        len += pkgi_snprintf(
+                data + len,
+                sizeof(data) - len,
+                "thumbnail_folder %s\n",
+                config.thumbnail_folder.c_str());
+    len += pkgi_snprintf(
+            data + len,
+            sizeof(data) - len,
+            "thumbnail_size %d\n",
+            config.thumbnail_size);
     if (!config.install_psp_psx_location.empty())
         len += pkgi_snprintf(
                 data + len,
@@ -355,12 +383,6 @@ void pkgi_save_config(const Config& config)
     {
         len += pkgi_snprintf(
                 data + len, sizeof(data) - len, "no_version_check 1\n");
-    }
-
-    if (config.install_psp_as_pbp)
-    {
-        len += pkgi_snprintf(
-                data + len, sizeof(data) - len, "install_psp_as_pbp 1\n");
     }
 
     pkgi_save(

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -10,7 +10,6 @@ typedef struct Config
     DbSortOrder order;
     uint32_t filter;
     int no_version_check;
-    int install_psp_as_pbp;
     std::string install_psp_psx_location;
 
     std::string games_url;
@@ -23,6 +22,17 @@ typedef struct Config
     std::string psp_dlcs_url;
 
     std::string comppack_url;
+
+    // Image panel settings
+    // thumbnail_url    : optional base URL for custom images fetched as
+    //                    {thumbnail_url}/{titleid}.jpg.
+    //                    Leave empty to fall back to the default PS Store cover.
+    // thumbnail_folder : local directory where images are stored/cached.
+    //                    Leave empty to use the default: ux0:pkgj/cover
+    // thumbnail_size   : panel size preset — 0=off, 1=small, 2=medium (default), 3=large
+    std::string thumbnail_url;
+    std::string thumbnail_folder;
+    int thumbnail_size{2};
 } Config;
 
 Config pkgi_load_config();

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,7 +2,14 @@
 
 #include "db.hpp"
 
+#include <array>
 #include <string>
+
+struct CustomConfigEntry
+{
+    std::string name;
+    std::string url;
+};
 
 typedef struct Config
 {
@@ -33,6 +40,8 @@ typedef struct Config
     std::string thumbnail_url;
     std::string thumbnail_folder;
     int thumbnail_size{2};
+
+    std::array<CustomConfigEntry, 5> custom_entries;
 } Config;
 
 Config pkgi_load_config();

--- a/src/configeditor.cpp
+++ b/src/configeditor.cpp
@@ -1,0 +1,178 @@
+#include "configeditor.hpp"
+
+#include <cstring>
+
+#include <fmt/format.h>
+
+#include "file.hpp"
+#include "imgui.hpp"
+#include "pkgi.hpp"
+extern "C"
+{
+#include "style.h"
+}
+
+namespace
+{
+constexpr float EditorW = VITA_WIDTH  * 0.8f;
+constexpr float EditorH = VITA_HEIGHT * 0.8f;
+}
+
+// ── Construction / destruction ───────────────────────────────────────────────
+
+ConfigEditor::ConfigEditor(Config& config)
+    : _config(config)
+{
+    _path = fmt::format("{}/config.txt", pkgi_get_config_folder());
+    load();
+}
+
+void ConfigEditor::load()
+{
+    _lines.clear();
+    if (!pkgi_file_exists(_path))
+        return;
+
+    auto data = pkgi_load(_path);
+
+    // Split raw bytes into lines; strip Windows-style \r
+    std::string cur;
+    cur.reserve(128);
+    for (uint8_t ch : data)
+    {
+        if (ch == '\r')
+            continue;
+        if (ch == '\n')
+        {
+            _lines.push_back(cur);
+            cur.clear();
+        }
+        else
+        {
+            cur += static_cast<char>(ch);
+        }
+    }
+    // Last line may have no trailing newline
+    if (!cur.empty())
+        _lines.push_back(cur);
+}
+
+void ConfigEditor::save()
+{
+    std::string out;
+    out.reserve(_lines.size() * 64);
+    for (const auto& l : _lines)
+    {
+        out += l;
+        out += '\n';
+    }
+    pkgi_save(_path, out.data(), static_cast<uint32_t>(out.size()));
+}
+
+void ConfigEditor::save_and_close()
+{
+    save();
+    _saved  = true;
+    _closed = true;
+}
+
+void ConfigEditor::close()
+{
+    _closed = true;
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+void ConfigEditor::render()
+{
+    // ── IME polling: must happen every frame ─────────────────────────────────
+    if (_ime_active && pkgi_dialog_input_update())
+    {
+        pkgi_dialog_input_get_text(_ime_buf, sizeof(_ime_buf));
+        if (_selected >= 0 && _selected < static_cast<int>(_lines.size()))
+            _lines[_selected] = _ime_buf;
+        _ime_active = false;
+    }
+
+    // ── Window ───────────────────────────────────────────────────────────────
+    ImGui::SetNextWindowPos(
+            ImVec2((VITA_WIDTH  - EditorW) / 2.f,
+                   (VITA_HEIGHT - EditorH) / 2.f));
+    ImGui::SetNextWindowSize(ImVec2(EditorW, EditorH), 0);
+
+    ImGui::Begin(
+            "Config Editor — config.txt###cfgedit",
+            nullptr,
+            ImGuiWindowFlags_NoResize   | ImGuiWindowFlags_NoMove   |
+            ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings |
+            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+
+    // ── Footer height reservation ─────────────────────────────────────────────
+    const float footer_h =
+            ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
+
+    // ── Scrollable row list ───────────────────────────────────────────────────
+    ImGui::BeginChild(
+            "##rows",
+            ImVec2(0.f, -footer_h),
+            false,
+            ImGuiWindowFlags_NavFlattened);
+
+    if (_lines.empty())
+    {
+        ImGui::TextDisabled("(file is empty or not found)");
+    }
+    else
+    {
+        for (int i = 0; i < static_cast<int>(_lines.size()); ++i)
+        {
+            const bool sel = (i == _selected);
+
+            // PushID makes each row unique even if two lines share identical text
+            ImGui::PushID(i);
+
+            const char* display =
+                    _lines[i].empty() ? " " : _lines[i].c_str();
+
+            const bool activated = ImGui::Selectable(
+                    display,
+                    sel,
+                    ImGuiSelectableFlags_AllowDoubleClick);
+
+            if (sel)
+                ImGui::SetItemDefaultFocus();
+
+            // D-pad navigation: track which row ImGui's nav cursor is on
+            if (ImGui::IsItemFocused())
+                _selected = i;
+
+            // X / OK press on the focused row opens IME
+            if (activated && !_ime_active)
+            {
+                _selected = i;
+                std::strncpy(
+                        _ime_buf, _lines[i].c_str(), sizeof(_ime_buf) - 1);
+                _ime_buf[sizeof(_ime_buf) - 1] = '\0';
+                pkgi_dialog_input_text("Edit line", _ime_buf);
+                _ime_active = true;
+            }
+
+            // Auto-scroll so the selected row stays visible
+            if (sel && ImGui::IsItemVisible() == false)
+                ImGui::SetScrollHereY(0.5f);
+
+            ImGui::PopID();
+        }
+    }
+
+    ImGui::EndChild();
+
+    // ── Footer ────────────────────────────────────────────────────────────────
+    ImGui::Separator();
+    ImGui::TextDisabled(
+            "[Cross] Edit line    "
+            "[Triangle] Save & close    "
+            "[Circle] Discard");
+
+    ImGui::End();
+}

--- a/src/configeditor.hpp
+++ b/src/configeditor.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "config.hpp"
+
+// ConfigEditor — full-screen ImGui panel that lets the user view and edit
+// every line of config.txt using the Vita native IME keyboard.
+//
+// Open it by setting config_editor = std::make_unique<ConfigEditor>(config)
+// in pkgi.cpp (triggered by MenuResultOpenConfigEditor from the menu).
+// Call render() once per frame.  Check is_closed() to know when to destroy it.
+// If was_saved() is true after close, call pkgi_load_config() to reload.
+class ConfigEditor
+{
+public:
+    explicit ConfigEditor(Config& config);
+    ~ConfigEditor() = default;
+
+    void render();
+
+    bool is_closed() const { return _closed; }
+    bool was_saved() const { return _saved; }
+
+    // Called from pkgi.cpp before input is zeroed:
+    void save_and_close(); // Triangle — save then close
+    void close();          // Circle  — discard
+
+private:
+    void load();
+    void save();
+
+    Config&                  _config;
+    std::string              _path;
+    std::vector<std::string> _lines;
+    int                      _selected{0};
+    bool                     _ime_active{false};
+    bool                     _closed{false};
+    bool                     _saved{false};
+    char                     _ime_buf[512]{};
+};

--- a/src/curlhttp.cpp
+++ b/src/curlhttp.cpp
@@ -1,0 +1,135 @@
+#include "curlhttp.hpp"
+
+#include "log.hpp"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cstring>
+
+// ---------------------------------------------------------------------------
+
+CurlHttp::CurlHttp(const std::atomic<bool>* external_abort)
+    : _external_abort(external_abort)
+{
+}
+
+CurlHttp::~CurlHttp()
+{
+    if (_curl)
+    {
+        curl_easy_cleanup(_curl);
+        _curl = nullptr;
+    }
+}
+
+void CurlHttp::start(const std::string& url, uint64_t offset)
+{
+    _body.clear();
+    _read_pos       = 0;
+    _status_code    = 0;
+    _content_length = -1;
+    // Do NOT reset _aborted here: abort() may have been called between
+    // construction and start(), and clearing the flag here would lose that
+    // signal, causing curl_easy_perform to run to its full timeout.
+    std::memset(_err_buf, 0, sizeof(_err_buf));
+
+    _curl = curl_easy_init();
+    if (!_curl)
+        throw HttpError("curl_easy_init failed");
+
+    curl_easy_setopt(_curl, CURLOPT_URL,              url.c_str());
+    curl_easy_setopt(_curl, CURLOPT_USERAGENT,        "libhttp/3.65 (PS Vita)");
+    curl_easy_setopt(_curl, CURLOPT_FOLLOWLOCATION,   1L);
+    curl_easy_setopt(_curl, CURLOPT_MAXREDIRS,        5L);
+    curl_easy_setopt(_curl, CURLOPT_SSL_VERIFYPEER,   0L);
+    curl_easy_setopt(_curl, CURLOPT_SSL_VERIFYHOST,   0L);
+    curl_easy_setopt(_curl, CURLOPT_CONNECTTIMEOUT,   30L);
+    curl_easy_setopt(_curl, CURLOPT_TIMEOUT,          60L);
+    curl_easy_setopt(_curl, CURLOPT_ERRORBUFFER,      _err_buf);
+    curl_easy_setopt(_curl, CURLOPT_WRITEFUNCTION,    write_cb);
+    curl_easy_setopt(_curl, CURLOPT_WRITEDATA,        &_body);
+    curl_easy_setopt(_curl, CURLOPT_XFERINFOFUNCTION, progress_cb);
+    curl_easy_setopt(_curl, CURLOPT_XFERINFODATA,     this);
+    curl_easy_setopt(_curl, CURLOPT_NOPROGRESS,       0L);
+
+    if (offset > 0)
+    {
+        const auto range = fmt::format("{}-", offset);
+        curl_easy_setopt(_curl, CURLOPT_RANGE, range.c_str());
+    }
+
+    const CURLcode res = curl_easy_perform(_curl);
+
+    curl_easy_getinfo(_curl, CURLINFO_RESPONSE_CODE, &_status_code);
+
+    curl_off_t cl = -1;
+    curl_easy_getinfo(_curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
+    _content_length = static_cast<int64_t>(cl);
+
+    curl_easy_cleanup(_curl);
+    _curl = nullptr;
+
+    if (res != CURLE_OK && res != CURLE_ABORTED_BY_CALLBACK)
+        throw HttpError(fmt::format(
+            "curl failed: {} ({})",
+            static_cast<int>(res),
+            _err_buf[0] ? _err_buf : curl_easy_strerror(res)));
+}
+
+int64_t CurlHttp::read(uint8_t* buffer, uint64_t size)
+{
+    if (_read_pos >= _body.size())
+        return 0;
+
+    const size_t available = _body.size() - _read_pos;
+    const size_t to_copy   =
+        static_cast<size_t>(std::min<uint64_t>(size, available));
+
+    std::memcpy(buffer, _body.data() + _read_pos, to_copy);
+    _read_pos += to_copy;
+    return static_cast<int64_t>(to_copy);
+}
+
+void CurlHttp::abort()
+{
+    _aborted = true;
+}
+
+int CurlHttp::get_status()
+{
+    return static_cast<int>(_status_code);
+}
+
+int64_t CurlHttp::get_length()
+{
+    return _content_length;
+}
+
+CurlHttp::operator bool() const
+{
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+
+size_t CurlHttp::write_cb(char* ptr, size_t size, size_t nmemb, void* ud)
+{
+    auto* body = static_cast<std::vector<uint8_t>*>(ud);
+    body->insert(body->end(), ptr, ptr + size * nmemb);
+    return size * nmemb;
+}
+
+int CurlHttp::progress_cb(void* ud,
+                           curl_off_t, curl_off_t,
+                           curl_off_t, curl_off_t)
+{
+    const auto* self = static_cast<CurlHttp*>(ud);
+    if (self->_aborted.load())
+        return 1;
+    if (self->_external_abort && self->_external_abort->load())
+        return 1;
+    return 0;
+}
+
+// CurlHttp object is used. We guard with std::call_once so it can also be

--- a/src/curlhttp.hpp
+++ b/src/curlhttp.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "http.hpp"
+
+#include <curl/curl.h>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Simple blocking Http implementation using libcurl.
+// Intended for small fetches (cover art, patch XML) that already run inside a
+// background thread — curl_easy_perform buffers the full response in memory
+// and returns. No internal threading or ring buffer needed.
+class CurlHttp : public Http
+{
+public:
+    // external_abort: optional pointer to an atomic flag owned by the caller.
+    // The progress callback checks it in addition to the local abort() call,
+    // so an abort() signal set before start() is invoked is never lost.
+    explicit CurlHttp(const std::atomic<bool>* external_abort = nullptr);
+    ~CurlHttp();
+
+    void start(const std::string& url, uint64_t offset) override;
+    int64_t read(uint8_t* buffer, uint64_t size) override;
+    void abort() override;
+
+    int get_status() override;
+    int64_t get_length() override;
+
+    explicit operator bool() const override;
+
+private:
+    std::vector<uint8_t> _body;
+    size_t               _read_pos       = 0;
+    long                 _status_code    = 0;
+    int64_t              _content_length = -1;
+    std::atomic<bool>    _aborted{false};
+
+    // Optional external abort flag (e.g. from ImageFetcher::_abort).
+    const std::atomic<bool>* _external_abort = nullptr;
+
+    // Kept alive until abort() or destruction so the progress callback can
+    // reference _aborted atomically.
+    CURL* _curl = nullptr;
+
+    char _err_buf[CURL_ERROR_SIZE] = {};
+
+    static size_t write_cb(char* ptr, size_t size, size_t nmemb, void* ud);
+    static int    progress_cb(void* ud,
+                              curl_off_t, curl_off_t,
+                              curl_off_t, curl_off_t);
+};

--- a/src/customhandler.cpp
+++ b/src/customhandler.cpp
@@ -1,0 +1,112 @@
+#include "customhandler.hpp"
+
+#include "dialog.hpp"
+#include "download.hpp"
+#include "downloader.hpp"
+#include "gameview.hpp"
+#include "pkgi.hpp"
+
+#include <fmt/format.h>
+
+namespace
+{
+void show_template_disabled(
+        const CustomInstallTemplateContext& context,
+        const char*                         flow_name)
+{
+    pkgi_dialog_error(
+            fmt::format(
+                    "Custom handler template is disabled.\n\n"
+                    "List: {}\nTSV: {}\nTemplate: {}\n\n"
+                    "Fill in src/customhandler.cpp to enable this flow.",
+                    context.list_name,
+                    context.tsv_url,
+                    flow_name)
+                    .c_str());
+}
+
+void handle_vita_like_template(const CustomInstallRequest& request)
+{
+    PKGI_UNUSED(request);
+    // Template based on the regular PSV branch in src/pkgi.cpp:
+    //   gameview = std::make_unique<GameView>(...)
+    // Keep this disabled until the custom TSV format and metadata are mapped.
+    show_template_disabled(*request.context, "PS Vita-like");
+}
+
+void handle_psx_like_template(const CustomInstallRequest& request)
+{
+    PKGI_UNUSED(request);
+    // Template based on the PS1 branch in src/pkgi.cpp where installation goes
+    // through pkgi_install_package / pkgi_start_download with PSX semantics.
+    show_template_disabled(*request.context, "PS1-like");
+}
+
+void handle_psm_like_template(const CustomInstallRequest& request)
+{
+    PKGI_UNUSED(request);
+    // Template based on the PSM branch in src/pkgi.cpp where install handling
+    // differs from Vita and PS1 content.
+    show_template_disabled(*request.context, "PSM-like");
+}
+
+void handle_psp_like_template(const CustomInstallRequest& request)
+{
+    PKGI_UNUSED(request);
+    // Template based on the PSP branch in src/pkgi.cpp / src/gameview.cpp.
+    show_template_disabled(*request.context, "PSP-like");
+}
+}
+
+CustomInstallTemplateContext pkgi_custom_make_template_context(
+        const std::string& list_name,
+        const std::string& tsv_url)
+{
+    CustomInstallTemplateContext context;
+    context.list_name = list_name;
+    context.tsv_url   = tsv_url;
+
+    // Placeholder: decide here how a custom list should map to an install flow.
+    // For now this remains Unknown so future work can classify lists as
+    // VitaLike / PsxLike / PsmLike / PspLike.
+    context.kind = CustomInstallTemplateKind::Unknown;
+
+    return context;
+}
+
+void pkgi_custom_open_list_template(
+        const std::string& list_name,
+        const std::string& tsv_url)
+{
+    const auto context = pkgi_custom_make_template_context(list_name, tsv_url);
+    pkgi_dialog_error(
+            fmt::format(
+                    "Custom list selected but loading is not implemented yet.\n\n"
+                    "List: {}\nTSV: {}\n\n"
+                    "Use src/customhandler.cpp as the template entry point.",
+                    context.list_name,
+                    context.tsv_url)
+                    .c_str());
+}
+
+void pkgi_custom_confirm_item_template(const CustomInstallRequest& request)
+{
+    switch (request.context->kind)
+    {
+    case CustomInstallTemplateKind::VitaLike:
+        handle_vita_like_template(request);
+        return;
+    case CustomInstallTemplateKind::PsxLike:
+        handle_psx_like_template(request);
+        return;
+    case CustomInstallTemplateKind::PsmLike:
+        handle_psm_like_template(request);
+        return;
+    case CustomInstallTemplateKind::PspLike:
+        handle_psp_like_template(request);
+        return;
+    case CustomInstallTemplateKind::Unknown:
+        show_template_disabled(*request.context, "Unknown");
+        return;
+    }
+}

--- a/src/customhandler.hpp
+++ b/src/customhandler.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+
+class Downloader;
+struct Config;
+struct DbItem;
+
+enum class CustomInstallTemplateKind
+{
+    Unknown,
+    VitaLike,
+    PsxLike,
+    PsmLike,
+    PspLike,
+};
+
+struct CustomInstallTemplateContext
+{
+    std::string               list_name;
+    std::string               tsv_url;
+    CustomInstallTemplateKind kind = CustomInstallTemplateKind::Unknown;
+};
+
+struct CustomInstallRequest
+{
+    const CustomInstallTemplateContext* context;
+    Config*                             config;
+    Downloader*                         downloader;
+    DbItem*                             item;
+};
+
+CustomInstallTemplateContext pkgi_custom_make_template_context(
+        const std::string& list_name,
+        const std::string& tsv_url);
+
+void pkgi_custom_open_list_template(
+        const std::string& list_name,
+        const std::string& tsv_url);
+
+void pkgi_custom_confirm_item_template(const CustomInstallRequest& request);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -491,6 +491,7 @@ void TitleDatabase::reload(
                         app_version,
                         fw_version,
                         /*selected=*/false,
+                        /*description=*/"",
                         /*user_flag=*/UserFlag::None,
                         /*user_comment=*/"",
                 });

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -285,7 +285,7 @@ void TitleDatabase::update(Mode mode, Http* http, const std::string& update_url)
     db_total = 0;
     db_size = 0;
 
-    LOGF("loading update from {}", update_url);
+    LOGF("Fetching game database from: {}", update_url);
 
     http->start(update_url, 0);
 
@@ -317,7 +317,7 @@ void TitleDatabase::update(Mode mode, Http* http, const std::string& update_url)
 
     pkgi_rename(tmppath, filepath);
 
-    LOG("finished downloading");
+    LOG("Game database download complete");
 }
 
 namespace
@@ -490,6 +490,9 @@ void TitleDatabase::reload(
                         last_modification,
                         app_version,
                         fw_version,
+                        /*selected=*/false,
+                        /*user_flag=*/UserFlag::None,
+                        /*user_comment=*/"",
                 });
         }
         catch (const std::exception& e)
@@ -505,7 +508,7 @@ void TitleDatabase::reload(
             [&](const auto& a, const auto& b)
             { return lower(a, b, sort_by, sort_order); });
 
-    LOGF("reloaded {}/{} items", db.size(), _title_count);
+    LOGF("Database loaded: {}/{} items", db.size(), _title_count);
 }
 
 void TitleDatabase::get_update_status(uint32_t* updated, uint32_t* total)

--- a/src/db.hpp
+++ b/src/db.hpp
@@ -68,6 +68,9 @@ struct DbItem
     std::string fw_version;
     bool selected;
 
+    // Fetched live from the PlayStation Store (not persisted to DB)
+    std::string description;
+
     // Personal annotation (loaded from AnnotationDatabase after reload)
     UserFlag    user_flag    = UserFlag::None;
     std::string user_comment;

--- a/src/db.hpp
+++ b/src/db.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "annotationdb.hpp"
 #include "http.hpp"
 
 #include <array>
@@ -66,6 +67,10 @@ struct DbItem
     std::string app_version;
     std::string fw_version;
     bool selected;
+
+    // Personal annotation (loaded from AnnotationDatabase after reload)
+    UserFlag    user_flag    = UserFlag::None;
+    std::string user_comment;
 };
 
 enum GameRegion

--- a/src/descriptionfetcher.cpp
+++ b/src/descriptionfetcher.cpp
@@ -5,6 +5,7 @@
 #include "pkgi.hpp"
 
 #include <fmt/format.h>
+#include <mutex>
 #include <vector>
 
 namespace

--- a/src/descriptionfetcher.cpp
+++ b/src/descriptionfetcher.cpp
@@ -1,0 +1,364 @@
+#include "descriptionfetcher.hpp"
+
+#include "curlhttp.hpp"
+#include "log.hpp"
+#include "pkgi.hpp"
+
+#include <fmt/format.h>
+#include <vector>
+
+namespace
+{
+// Returns the PSN Store country code for this item's region.
+static std::string get_country(const DbItem* item)
+{
+    switch (pkgi_get_region(item->titleid))
+    {
+    case RegionASA:
+        if (item->name.find("CHN") != std::string::npos)
+            return "CN";
+        if (item->content.substr(0, 6) == "HP0507")
+            return "KR";
+        return "HK";
+    case RegionJPN:
+        return "JP";
+    case RegionEUR:
+        return "GB";
+    default:
+        return "US";
+    }
+}
+
+static std::string get_language(const DbItem* item)
+{
+    switch (pkgi_get_region(item->titleid))
+    {
+    case RegionASA:
+    {
+        if (item->name.find("CHN") != std::string::npos)
+            return "zh";
+        if (item->content.substr(0, 6) == "HP0507")
+            return "ko";
+        return "zh";
+    }
+    case RegionJPN:
+        return "ja";
+    default:
+        return "en";
+    }
+}
+
+// Minimal JSON string extractor: finds  "key":"value"  and returns the
+// unescaped value.  Handles the common escape sequences used in PSN JSON.
+static std::string extract_json_string(
+        const std::string& json, const std::string& key)
+{
+    const auto search = "\"" + key + "\":\"";
+    auto pos = json.find(search);
+    if (pos == std::string::npos)
+        return {};
+    pos += search.size();
+
+    std::string result;
+    result.reserve(256);
+    while (pos < json.size() && json[pos] != '"')
+    {
+        if (json[pos] == '\\' && pos + 1 < json.size())
+        {
+            ++pos;
+            switch (json[pos])
+            {
+            case '"':
+                result += '"';
+                break;
+            case '\\':
+                result += '\\';
+                break;
+            case '/':
+                result += '/';
+                break;
+            case 'n':
+                result += '\n';
+                break;
+            case 'r':
+                break; // drop bare CR
+            case 't':
+                result += ' ';
+                break;
+            default:
+                result += json[pos];
+                break;
+            }
+        }
+        else
+        {
+            result += json[pos];
+        }
+        ++pos;
+    }
+    return result;
+}
+// Strip HTML tags and decode common entities from PSN store descriptions.
+// Converts <br>, <br/>, <br /> to newlines; strips all other tags;
+// decodes &amp; &lt; &gt; &quot; &apos; &nbsp; and numeric &#NNN; / &#xHH;
+// Collapses runs of 3+ newlines to 2.
+static std::string clean_html(const std::string& html)
+{
+    std::string out;
+    out.reserve(html.size());
+
+    size_t i = 0;
+    const size_t n = html.size();
+
+    while (i < n)
+    {
+        if (html[i] == '<')
+        {
+            // Collect tag name
+            size_t j = i + 1;
+            while (j < n && html[j] != '>' && html[j] != ' ' && html[j] != '/')
+                ++j;
+            const std::string tag = html.substr(i + 1, j - (i + 1));
+
+            // Advance past the closing >
+            while (j < n && html[j] != '>')
+                ++j;
+            if (j < n)
+                ++j; // skip '>'
+
+            // <br> / <br/> → newline
+            if (tag == "br" || tag == "BR")
+                out += '\n';
+            // else: strip all other tags
+
+            i = j;
+        }
+        else if (html[i] == '&')
+        {
+            size_t j = i + 1;
+            while (j < n && html[j] != ';' && (j - i) < 12)
+                ++j;
+            if (j < n && html[j] == ';')
+            {
+                const std::string entity = html.substr(i + 1, j - i - 1);
+                if (entity == "amp")        out += '&';
+                else if (entity == "lt")    out += '<';
+                else if (entity == "gt")    out += '>';
+                else if (entity == "quot")  out += '"';
+                else if (entity == "apos")  out += '\'';
+                else if (entity == "nbsp")  out += ' ';
+                else if (!entity.empty() && entity[0] == '#')
+                {
+                    // Numeric entity — encode as UTF-8
+                    unsigned long cp = 0;
+                    try {
+                        if (entity.size() > 1 &&
+                            (entity[1] == 'x' || entity[1] == 'X'))
+                            cp = std::stoul(entity.substr(2), nullptr, 16);
+                        else
+                            cp = std::stoul(entity.substr(1), nullptr, 10);
+                    } catch (...) {}
+                    // Encode codepoint as UTF-8
+                    if (cp < 0x80)
+                    {
+                        out += static_cast<char>(cp);
+                    }
+                    else if (cp < 0x800)
+                    {
+                        out += static_cast<char>(0xC0 | (cp >> 6));
+                        out += static_cast<char>(0x80 | (cp & 0x3F));
+                    }
+                    else if (cp < 0x10000)
+                    {
+                        out += static_cast<char>(0xE0 | (cp >> 12));
+                        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+                        out += static_cast<char>(0x80 | (cp & 0x3F));
+                    }
+                    else if (cp < 0x110000)
+                    {
+                        out += static_cast<char>(0xF0 | (cp >> 18));
+                        out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+                        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+                        out += static_cast<char>(0x80 | (cp & 0x3F));
+                    }
+                }
+                else
+                {
+                    // Unknown entity — keep verbatim
+                    out += html.substr(i, j - i + 1);
+                }
+                i = j + 1; // skip ';'
+            }
+            else
+            {
+                // Not a valid entity — emit as-is
+                out += html[i++];
+            }
+        }
+        else
+        {
+            out += html[i++];
+        }
+    }
+
+    // Collapse runs of 3+ newlines to 2
+    std::string collapsed;
+    collapsed.reserve(out.size());
+    int nl_run = 0;
+    for (char c : out)
+    {
+        if (c == '\n')
+        {
+            ++nl_run;
+            if (nl_run <= 2)
+                collapsed += c;
+        }
+        else
+        {
+            nl_run = 0;
+            collapsed += c;
+        }
+    }
+
+    // Trim leading/trailing whitespace
+    size_t start = collapsed.find_first_not_of(" \t\n\r");
+    size_t end   = collapsed.find_last_not_of(" \t\n\r");
+    if (start == std::string::npos)
+        return {};
+    return collapsed.substr(start, end - start + 1);
+}
+} // namespace
+
+DescriptionFetcher::DescriptionFetcher(const DbItem* item)
+    : _item(item)
+    , _mutex("desc_fetcher_mutex")
+    , _thread("desc_fetcher", [this] { do_request(); })
+{
+}
+
+DescriptionFetcher::~DescriptionFetcher()
+{
+    {
+        std::lock_guard<Mutex> lock(_mutex);
+        _abort = true;
+    }
+    _thread.join();
+}
+
+DescriptionFetcher::Status DescriptionFetcher::get_status()
+{
+    std::lock_guard<Mutex> lock(_mutex);
+    return _status;
+}
+
+std::string DescriptionFetcher::get_description()
+{
+    std::lock_guard<Mutex> lock(_mutex);
+    return _description;
+}
+
+void DescriptionFetcher::do_request()
+{
+    try
+    {
+        {
+            std::lock_guard<Mutex> lock(_mutex);
+            if (_abort)
+                return;
+        }
+
+        const auto country  = get_country(_item);
+        const auto language = get_language(_item);
+
+        // Chihiro container endpoint — returns a JSON object that includes
+        // "long_desc" (and "short_desc" as fallback).
+        const auto url = fmt::format(
+                "https://store.playstation.com/store/api/chihiro/"
+                "00_09_000/container/{}/{}/19/{}",
+                country,
+                language,
+                _item->content);
+
+        CurlHttp http;
+        try
+        {
+            http.start(url, 0);
+        }
+        catch (const std::exception& e)
+        {
+            LOGFW("[DescriptionFetcher] HTTP start failed for {}: {}",
+                  _item->titleid,
+                  e.what());
+            std::lock_guard<Mutex> lock(_mutex);
+            _status = Status::Error;
+            return;
+        }
+
+        if (http.get_status() == 404)
+        {
+            std::lock_guard<Mutex> lock(_mutex);
+            _status = Status::NotAvailable;
+            return;
+        }
+
+        // Read up to 512 KB — description JSON is typically < 32 KB.
+        constexpr size_t MAX_BYTES = 512 * 1024;
+        std::vector<uint8_t> data;
+        data.reserve(32 * 1024);
+        size_t pos = 0;
+        while (true)
+        {
+            {
+                std::lock_guard<Mutex> lock(_mutex);
+                if (_abort)
+                    return;
+            }
+            if (pos == data.size())
+                data.resize(pos + 4096);
+
+            int64_t n = 0;
+            try
+            {
+                n = http.read(data.data() + pos, data.size() - pos);
+            }
+            catch (...)
+            {
+                break;
+            }
+            if (n == 0)
+                break;
+            pos += static_cast<size_t>(n);
+            if (pos > MAX_BYTES)
+                break;
+        }
+        data.resize(pos);
+
+        const std::string json(
+                reinterpret_cast<const char*>(data.data()), data.size());
+
+        // Try long description first, fall back to short.
+        auto desc = extract_json_string(json, "long_desc");
+        if (desc.empty())
+            desc = extract_json_string(json, "short_desc");
+
+        std::lock_guard<Mutex> lock(_mutex);
+        if (!_abort)
+        {
+            if (desc.empty())
+                _status = Status::NotAvailable;
+            else
+            {
+                _description = clean_html(desc);
+                _status      = Status::Found;
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        LOGFW("[DescriptionFetcher] exception for {}: {}",
+              _item->titleid,
+              e.what());
+        std::lock_guard<Mutex> lock(_mutex);
+        _status = Status::Error;
+    }
+}

--- a/src/descriptionfetcher.hpp
+++ b/src/descriptionfetcher.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "db.hpp"
+#include "thread.hpp"
+
+#include <string>
+
+// Fetches the long description for a game from the PlayStation Store (chihiro
+// container API).  Runs in its own background thread; main thread polls
+// get_status() and reads get_description() only after Status::Found.
+class DescriptionFetcher
+{
+public:
+    enum class Status
+    {
+        Fetching,
+        Found,
+        NotAvailable,
+        Error,
+    };
+
+    // Starts the background fetch immediately.
+    DescriptionFetcher(const DbItem* item);
+    ~DescriptionFetcher();
+
+    Status            get_status();
+    // Safe to call from the main thread at any time; returns empty string
+    // until Status::Found.
+    std::string       get_description();
+
+private:
+    const DbItem* _item;
+
+    Mutex       _mutex;
+    bool        _abort{false};
+    Status      _status{Status::Fetching};
+    std::string _description;
+
+    Thread _thread;
+
+    void do_request();
+};

--- a/src/dialog.cpp
+++ b/src/dialog.cpp
@@ -70,7 +70,7 @@ void pkgi_dialog_message(const char* text, int allow_close)
 
 void pkgi_dialog_error(const char* text)
 {
-    LOGF("Error dialog: {}", text);
+    LOGF("Showing error dialog: {}", text);
 
     pkgi_dialog_lock();
 

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -53,7 +53,7 @@ Download::Download(std::unique_ptr<Http> http) : _http(std::move(http))
 
 void Download::download_start(void)
 {
-    LOGF("resuming pkg download from {} offset", download_offset);
+    LOGF("Resuming PKG download at offset {}", download_offset);
     info_update = pkgi_time_msec() + 1000;
     update_status("Downloading");
 }
@@ -394,7 +394,7 @@ void Download::download_data(
 
     if (!*_http)
     {
-        LOGF("requesting {} @ {}", download_url, download_offset);
+        LOGF("HTTP GET {} at offset {}", download_url, download_offset);
         _http->start(download_url, download_offset);
 
         const int64_t http_length = _http->get_length();
@@ -405,7 +405,7 @@ void Download::download_data(
 
         download_size = http_length + download_offset;
 
-        LOGF("http response length = {}, total pkg size = {}",
+        LOGF("HTTP Content-Length: {}, total PKG size: {}",
              http_length,
              download_size);
         info_start = pkgi_time_msec();
@@ -480,7 +480,7 @@ void Download::create_file()
 
     pkgi_mkdirs(folder.c_str());
 
-    LOGF("creating {} file", item_name);
+    LOGF("Creating PKG file: {}", item_name);
     item_file = pkgi_create(item_path.c_str());
     if (!item_file)
         throw formatEx<DownloadError>("cannot create file {}", item_name);
@@ -488,7 +488,7 @@ void Download::create_file()
 
 void Download::open_file()
 {
-    LOGF("opening {} file for resume", item_name);
+    LOGF("Opening file for resume: {}", item_name);
     item_file = pkgi_openrw(item_path.c_str());
     if (!item_file)
         throw formatEx<DownloadError>("cannot create file {}", item_name);
@@ -496,7 +496,7 @@ void Download::open_file()
 
 int Download::download_head(const uint8_t* rif)
 {
-    LOG("downloading pkg head");
+    LOG("Downloading PKG header");
 
     item_name = "Preparing...";
     item_path = fmt::format("{}/sce_sys/package/head.bin", root);
@@ -649,7 +649,7 @@ int Download::download_head(const uint8_t* rif)
             0,
             1);
 
-    LOG("head.bin downloaded");
+    LOG("PKG header (head.bin) downloaded");
     return 1;
 }
 
@@ -863,7 +863,7 @@ void Download::download_file_content_to_edat(uint64_t item_size)
 
 int Download::download_files(void)
 {
-    LOG("downloading encrypted files");
+    LOG("Downloading encrypted PKG content files");
 
     BOOST_SCOPE_EXIT_ALL(&)
     {
@@ -1031,13 +1031,13 @@ int Download::download_files(void)
         resuming = false;
     }
 
-    LOG("all files decrypted");
+    LOG("All PKG files decrypted successfully");
     return 1;
 }
 
 int Download::download_tail(void)
 {
-    LOG("downloading tail.bin");
+    LOG("Downloading PKG tail (tail.bin)");
 
     BOOST_SCOPE_EXIT_ALL(&)
     {
@@ -1070,7 +1070,7 @@ int Download::download_tail(void)
                 down.data(), read, 0, content_type != CONTENT_TYPE_PSX_GAME);
     }
 
-    LOG("tail.bin downloaded");
+    LOG("PKG tail (tail.bin) downloaded");
     return 1;
 }
 
@@ -1078,24 +1078,24 @@ int Download::check_integrity(const uint8_t* digest)
 {
     if (!digest)
     {
-        LOG("no integrity provided, skipping check");
+        LOG("No integrity hash provided, skipping verification");
         return 1;
     }
 
     uint8_t check[SHA256_DIGEST_SIZE];
     sha256_finish(&sha, check);
 
-    LOG("checking integrity of pkg");
+    LOG("Verifying PKG integrity");
     if (!pkgi_memequ(digest, check, SHA256_DIGEST_SIZE))
     {
-        LOG("pkg integrity is wrong, removing head.bin & resume data");
+        LOG_ERR("PKG integrity check failed, removing head.bin and resume data");
 
         pkgi_rm(fmt::format("{}/sce_sys/package/head.bin", root).c_str());
 
         throw DownloadError("pkg integrity failed, try downloading again");
     }
 
-    LOG("pkg integrity check succeeded");
+    LOG("PKG integrity verified");
     return 1;
 }
 
@@ -1266,7 +1266,7 @@ int Download::pkgi_download(
     }
     catch (const ResumeError& e)
     {
-        LOGF("deleting resume file");
+        LOGFE("Deleting resume file");
         try
         {
             pkgi_rm(fmt::format("{}.resume", root).c_str());
@@ -1274,7 +1274,7 @@ int Download::pkgi_download(
         }
         catch (const std::exception& e)
         {
-            LOGF("failed to delete resume file");
+            LOGFW("Failed to delete resume file");
         }
         throw;
     }
@@ -1318,7 +1318,7 @@ void Download::deserialize_state()
 
     try
     {
-        LOG("download resume file found");
+        LOG("Resume file found, will resume download");
 
         const auto head_path = fmt::format("{}/sce_sys/package/head.bin", root);
         head = pkgi_load(head_path);
@@ -1353,7 +1353,7 @@ void Download::deserialize_state()
 
         resuming = true;
 
-        LOGF("resuming download from {}/{}", download_offset, download_size);
+        LOGF("Resuming download: offset {}, size {}", download_offset, download_size);
     }
     catch (const std::exception& e)
     {

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -39,21 +39,21 @@ std::string type_to_string(Type type)
 Downloader::Downloader()
     : _cond("downloader_cond"), _thread("downloader_thread", [this] { run(); })
 {
-    LOG("new downloader");
+    LOG("Downloader initialized");
 }
 
 Downloader::~Downloader()
 {
-    LOG("destroying downloader");
+    LOG("Downloader shutdown requested");
     _dying = true;
     _cond.notify_one();
     _thread.join();
-    LOG("downloader destroyed");
+    LOG("Downloader thread stopped");
 }
 
 void Downloader::add(const DownloadItem& d)
 {
-    LOG("adding download %s", d.name.c_str());
+    LOG("Queued download: %s", d.name.c_str());
     {
         ScopeLock _(_cond.get_mutex());
         _queue.push_back(d);
@@ -136,7 +136,7 @@ void Downloader::run()
         }
         catch (const std::exception& e)
         {
-            LOG("download error: %s", e.what());
+            LOG_ERR("Download failed: %s", e.what());
             error(e.what());
         }
     }
@@ -150,7 +150,7 @@ void Downloader::do_download_package(const DownloadItem& item)
     };
 
     ScopeProcessLock _;
-    LOG("downloading %s", item.name.c_str());
+    LOG("[%s] Download started: %s", type_to_string(item.type).c_str(), item.name.c_str());
     auto download = std::make_unique<Download>(std::make_unique<VitaHttp>());
     download->save_as_iso = item.save_as_iso;
     download->update_progress_cb =
@@ -168,7 +168,7 @@ void Downloader::do_download_package(const DownloadItem& item)
                 item.rif.empty() ? nullptr : item.rif.data(),
                 item.digest.empty() ? nullptr : item.digest.data()))
         return;
-    LOG("download of %s completed!", item.name.c_str());
+    LOG("[%s] Download complete: %s", type_to_string(item.type).c_str(), item.name.c_str());
     switch (item.type)
     {
     case Game:
@@ -202,7 +202,7 @@ void Downloader::do_download_package(const DownloadItem& item)
     pkgi_rm(fmt::format("{}pkgj/{}.resume", item.partition, item.content)
                     .c_str());
     pkgi_delete_dir(fmt::format("{}pkgj/{}", item.partition, item.content));
-    LOG("install of %s completed!", item.name.c_str());
+    LOG("[%s] Install complete: %s", type_to_string(item.type).c_str(), item.name.c_str());
 }
 
 void Downloader::do_download_comppack(const DownloadItem& item)
@@ -213,7 +213,7 @@ void Downloader::do_download_comppack(const DownloadItem& item)
     };
 
     ScopeProcessLock _;
-    LOGF("downloading comppack {}", item.url);
+    LOGF("Comppack download started: {}", item.url);
     auto download =
             std::make_unique<FileDownload>(std::make_unique<VitaHttp>());
 
@@ -227,12 +227,12 @@ void Downloader::do_download_comppack(const DownloadItem& item)
 
     download->download(
             item.partition.c_str(), item.content.c_str(), item.url.c_str());
-    LOGF("download of comppack {} completed!", item.url);
+    LOGF("Comppack download complete: {}", item.url);
     pkgi_install_comppack(
             item.content, item.type == CompPackPatch, item.version);
     pkgi_rm(fmt::format("{}pkgj/{}-comp.ppk", item.partition, item.content)
                     .c_str());
-    LOG("install of %s completed!", item.name.c_str());
+    LOG("Comppack install complete: %s", item.name.c_str());
 }
 
 void Downloader::do_download(const DownloadItem& item)

--- a/src/filedownload.cpp
+++ b/src/filedownload.cpp
@@ -26,7 +26,7 @@ void FileDownload::update_progress()
 
 void FileDownload::start_download()
 {
-    LOGF("requesting {}", download_url);
+    LOGF("HTTP GET: {}", download_url);
     _http->start(download_url, 0);
 
     const auto http_length = _http->get_length();
@@ -34,7 +34,7 @@ void FileDownload::start_download()
         throw DownloadError("HTTP response has unknown length");
 
     download_size = http_length;
-    LOGF("http response length = {}", download_size);
+    LOGF("Download size: {} bytes", download_size);
 }
 
 void FileDownload::download_data(uint32_t size)
@@ -66,7 +66,7 @@ void FileDownload::download_data(uint32_t size)
 
 void FileDownload::download_file()
 {
-    LOG("downloading encrypted files");
+    LOG("Downloading encrypted content files");
 
     LOGF("creating {} file", root);
     item_file = pkgi_create(root.c_str());

--- a/src/filehttp.cpp
+++ b/src/filehttp.cpp
@@ -8,7 +8,7 @@ FileHttp::FileHttp(const std::string& path) : override_path(path)
 
 void FileHttp::start(const std::string& url, uint64_t offset)
 {
-    LOGF("Fake downloading {}", url);
+    LOGF("[Debug] Simulated HTTP download: {}", url);
     f.open(override_path.empty() ? url : override_path);
     f.seekg(offset, std::ios::beg);
 }

--- a/src/gameview.cpp
+++ b/src/gameview.cpp
@@ -5,31 +5,139 @@
 #include "dialog.hpp"
 #include "file.hpp"
 #include "imgui.hpp"
+#include "pkgi.hpp"
 extern "C"
 {
 #include "style.h"
 }
 
+#ifndef PKGI_SIMULATOR
+#include <vita2d.h>
+// vita2d_texture_get_width / _height are declared in vita2d.h
+#else
+#include <SDL2/SDL.h>
+// On Linux/simulator, vita2d_texture is opaque (reinterpreted as SDL_Texture).
+// Provide thin wrappers so the rest of gameview.cpp compiles without ifdefs.
+static inline float vita2d_texture_get_width(vita2d_texture* t)
+{
+    int w = 0;
+    if (t) SDL_QueryTexture(reinterpret_cast<SDL_Texture*>(t), nullptr, nullptr, &w, nullptr);
+    return static_cast<float>(w);
+}
+static inline float vita2d_texture_get_height(vita2d_texture* t)
+{
+    int h = 0;
+    if (t) SDL_QueryTexture(reinterpret_cast<SDL_Texture*>(t), nullptr, nullptr, nullptr, &h);
+    return static_cast<float>(h);
+}
+#endif
+
 namespace
 {
-constexpr unsigned GameViewWidth = VITA_WIDTH * 0.8;
-constexpr unsigned GameViewHeight = VITA_HEIGHT * 0.8;
+constexpr unsigned GameViewWidth  = VITA_WIDTH  * 0.95;
+constexpr unsigned GameViewHeight = VITA_HEIGHT * 0.82;
+
+// Thumbnail panel size presets indexed by config.thumbnail_size
+// 0=off, 1=small, 2=medium, 3=large
+struct ThumbSize { float w, h; };
+constexpr ThumbSize kThumbSizes[] = {
+    {  0.f,   0.f}, // 0 off
+    {203.f, 203.f}, // 1 small   (square, 90% of previous width)
+    {284.f, 284.f}, // 2 medium
+    {365.f, 365.f}, // 3 large
+};
+constexpr int kThumbSizeCount = 4;
+
+const char* presence_label(DbPresence presence)
+{
+    switch (presence)
+    {
+    case PresenceUnknown:
+        return "Unknown";
+    case PresenceIncomplete:
+        return "Incomplete";
+    case PresenceInstalling:
+        return "Installing";
+    case PresenceInstalled:
+        return "Installed";
+    case PresenceMissing:
+        return "Missing";
+    case PresenceGamePresent:
+        return "Base game present";
+    }
+    return "Unknown";
+}
+
+std::string friendly_size(int64_t size)
+{
+    if (size <= 0)
+        return "unknown";
+    if (size < 1000LL)
+        return fmt::format("{} B", size);
+    if (size < 1000LL * 1000)
+        return fmt::format("{:.1f} kB", static_cast<double>(size) / 1000.0);
+    if (size < 1000LL * 1000 * 1000)
+        return fmt::format("{:.1f} MB", static_cast<double>(size) / 1000.0 / 1000.0);
+    return fmt::format("{:.2f} GB", static_cast<double>(size) / 1000.0 / 1000.0 / 1000.0);
+}
+
+void draw_centered_status_text(
+        ImDrawList* dl,
+        ImVec2 panel_min,
+        float panel_w,
+        float panel_h,
+        const char* line1,
+        const char* line2,
+        ImU32 color)
+{
+    ImVec2 s1 = ImGui::CalcTextSize(line1);
+    ImVec2 s2 = line2 ? ImGui::CalcTextSize(line2) : ImVec2(0.f, 0.f);
+    const float gap = line2 ? 2.f : 0.f;
+    const float total_h = s1.y + (line2 ? gap + s2.y : 0.f);
+
+    dl->AddText(
+            ImVec2(panel_min.x + (panel_w - s1.x) * 0.5f,
+                   panel_min.y + (panel_h - total_h) * 0.5f),
+            color,
+            line1);
+
+    if (line2)
+    {
+        dl->AddText(
+                ImVec2(panel_min.x + (panel_w - s2.x) * 0.5f,
+                       panel_min.y + (panel_h - total_h) * 0.5f + s1.y + gap),
+                color,
+                line2);
+    }
+}
 }
 
 GameView::GameView(
+        Mode mode,
         const Config* config,
         Downloader* downloader,
         DbItem* item,
         std::optional<CompPackDatabase::Item> base_comppack,
-        std::optional<CompPackDatabase::Item> patch_comppack)
-    : _config(config)
+        std::optional<CompPackDatabase::Item> patch_comppack,
+        AnnotationDatabase* annotationDb)
+    : _mode(mode)
+    , _config(config)
     , _downloader(downloader)
     , _item(item)
     , _base_comppack(base_comppack)
     , _patch_comppack(patch_comppack)
-    , _patch_info_fetcher(item->titleid)
-    , _image_fetcher(item)
+    , _image_fetcher(config, item)
+    , _annotationDb(annotationDb)
+    , _annotation(annotationDb ? annotationDb->get(item->titleid) : UserAnnotation{})
 {
+    // Populate the text buffer from the saved annotation
+    std::strncpy(_comment_buf, _annotation.comment.c_str(),
+                 sizeof(_comment_buf) - 1);
+    _comment_buf[sizeof(_comment_buf) - 1] = '\0';
+
+    if (is_vita_mode())
+        _patch_info_fetcher = std::make_unique<PatchInfoFetcher>(item->titleid);
+
     refresh();
 }
 
@@ -50,105 +158,279 @@ void GameView::render()
                     ImGuiWindowFlags_NoCollapse |
                     ImGuiWindowFlags_NoSavedSettings);
 
-    ImGui::PushTextWrapPos(
-            _image_fetcher.get_texture() == nullptr ? 0.f
-                                                    : GameViewWidth - 300.f);
-    ImGui::Text(fmt::format("Firmware version: {}", pkgi_get_system_version())
-                        .c_str());
-    ImGui::Text(
-            fmt::format(
-                    "Required firmware version: {}", get_min_system_version())
-                    .c_str());
-
-    ImGui::Text(" ");
-
-    ImGui::Text(fmt::format(
-                        "Installed game version: {}",
-                        _game_version.empty() ? "not installed" : _game_version)
-                        .c_str());
-    if (_comppack_versions.present && _comppack_versions.base.empty() &&
-        _comppack_versions.patch.empty())
     {
-        ImGui::Text("Installed compatibility pack: unknown version");
+        const int tsz = std::max(0, std::min(
+                _config->thumbnail_size, kThumbSizeCount - 1));
+        const float kImagePanelW = kThumbSizes[tsz].w;
+        const float kImagePanelH = kThumbSizes[tsz].h;
+        auto* thumb_tex = _image_fetcher.get_texture();
+        const auto image_status = _image_fetcher.get_status();
+
+        if (kImagePanelW > 0.f)
+        {
+            const ImGuiStyle& style = ImGui::GetStyle();
+            ImVec2 win_pos = ImGui::GetWindowPos();
+            const float title_bar_h = ImGui::GetFrameHeight();
+            ImVec2 panel_min(
+                    win_pos.x + (float)GameViewWidth
+                            - style.WindowPadding.x - kImagePanelW,
+                    win_pos.y + title_bar_h + style.WindowPadding.y);
+            ImVec2 panel_max(
+                    panel_min.x + kImagePanelW,
+                    panel_min.y + kImagePanelH);
+
+            ImDrawList* dl = ImGui::GetForegroundDrawList();
+            dl->AddRectFilled(panel_min, panel_max, IM_COL32(20, 20, 20, 230), 3.f);
+            dl->AddRect(panel_min, panel_max, IM_COL32(110, 110, 110, 255), 3.f);
+
+            if (thumb_tex)
+            {
+                float tw = static_cast<float>(vita2d_texture_get_width(thumb_tex));
+                float th = static_cast<float>(vita2d_texture_get_height(thumb_tex));
+                const float inner_w = kImagePanelW - 6.f;
+                const float inner_h = kImagePanelH - 6.f;
+                if (tw > inner_w) { th = th * inner_w / tw; tw = inner_w; }
+                if (th > inner_h) { tw = tw * inner_h / th; th = inner_h; }
+                // Top-align: centre horizontally, pin to top of inner area
+                ImVec2 img_min(
+                        panel_min.x + (kImagePanelW - tw) * 0.5f,
+                        panel_min.y + 3.f);
+                ImVec2 img_max(img_min.x + tw, img_min.y + th);
+                dl->AddImage((ImTextureID)thumb_tex, img_min, img_max);
+            }
+            else
+            {
+                if (image_status == ImageFetcher::Status::Downloading)
+                {
+                    draw_centered_status_text(
+                            dl,
+                            panel_min,
+                            kImagePanelW,
+                            kImagePanelH,
+                            "Downloading",
+                            "cover",
+                            IM_COL32(180, 190, 220, 220));
+                }
+                else if (image_status == ImageFetcher::Status::Error)
+                {
+                    draw_centered_status_text(
+                            dl,
+                            panel_min,
+                            kImagePanelW,
+                            kImagePanelH,
+                            "Download error",
+                            "no image available",
+                            IM_COL32(210, 150, 150, 220));
+                }
+            }
+        }
+    }
+
+    {
+        const int tsz = std::max(0, std::min(
+                _config->thumbnail_size, kThumbSizeCount - 1));
+        const float panelW = kThumbSizes[tsz].w;
+        ImGui::PushTextWrapPos(
+                panelW > 0.f
+                ? (float)GameViewWidth
+                        - ImGui::GetStyle().WindowPadding.x
+                        - panelW
+                        - ImGui::GetStyle().ItemSpacing.x
+                : 0.f);
+    }
+
+    if (is_vita_mode())
+    {
+        ImGui::Text(fmt::format("Firmware version: {}", pkgi_get_system_version()).c_str());
+        ImGui::Text(fmt::format("Required firmware version: {}", get_min_system_version()).c_str());
+        ImGui::Text(" ");
+        ImGui::Text(fmt::format(
+                            "Installed game version: {}",
+                            _game_version.empty() ? "not installed" : _game_version)
+                            .c_str());
+        if (_comppack_versions.present && _comppack_versions.base.empty() &&
+            _comppack_versions.patch.empty())
+        {
+            ImGui::Text("Installed compatibility pack: unknown version");
+        }
+        else
+        {
+            ImGui::Text(fmt::format(
+                                "Installed base compatibility pack: {}",
+                                _comppack_versions.base.empty() ? "no" : "yes")
+                                .c_str());
+            ImGui::Text(fmt::format(
+                                "Installed patch compatibility pack version: {}",
+                                _comppack_versions.patch.empty() ? "none"
+                                                                 : _comppack_versions.patch)
+                                .c_str());
+        }
+        ImGui::Text(" ");
+        printDiagnostic();
+        ImGui::Text(" ");
     }
     else
-    {
-        ImGui::Text(fmt::format(
-                            "Installed base compatibility pack: {}",
-                            _comppack_versions.base.empty() ? "no" : "yes")
-                            .c_str());
-        ImGui::Text(fmt::format(
-                            "Installed patch compatibility pack version: {}",
-                            _comppack_versions.patch.empty()
-                                    ? "none"
-                                    : _comppack_versions.patch)
-                            .c_str());
+    {        
+        ImGui::Text(fmt::format("Content ID: {}",
+                                _item->content.empty() ? "unknown" : _item->content).c_str());
+        ImGui::Text(fmt::format("Package size: {}", friendly_size(_item->size)).c_str());
+        ImGui::Text(fmt::format("Last update: {}",
+                                _item->date.empty() ? "unknown" : _item->date).c_str());
+        ImGui::Text(" ");
+        ImGui::Text("Diagnostic:");
+        ImGui::Text(fmt::format("- Status: {}", presence_label(_item->presence)).c_str());
+        ImGui::Text(fmt::format("- NoPspEmuDrm kernel plugin: {}",
+                                _nopspemudrm_present ? "present" : "not detected").c_str());
+        ImGui::Text("- Install as ISO: available");
+        if (_nopspemudrm_present)
+            ImGui::Text("- LiveArea PBP queue: available");
+        else
+            ImGui::Text("- LiveArea PBP queue: unavailable without plugin");
+        ImGui::Text(" ");
     }
-
-    ImGui::Text(" ");
-
-    printDiagnostic();
-
-    ImGui::Text(" ");
 
     ImGui::PopTextWrapPos();
 
-    if (_patch_info_fetcher.get_status() == PatchInfoFetcher::Status::Found)
+    if (is_vita_mode() && _patch_info_fetcher &&
+        _patch_info_fetcher->get_status() == PatchInfoFetcher::Status::Found)
     {
         if (ImGui::Button("Install game and patch###installgame"))
             start_download_package();
+        ImGui::SetItemDefaultFocus();
+        if (ImGui::IsItemFocused())
+            ImGui::SetScrollY(0.0f);
     }
-    else
+    else if (is_vita_mode())
     {
         if (ImGui::Button("Install game###installgame"))
             start_download_package();
+        ImGui::SetItemDefaultFocus();
+        if (ImGui::IsItemFocused())
+            ImGui::SetScrollY(0.0f);
     }
-    ImGui::SetItemDefaultFocus();
+    else
+    {
+        if (ImGui::Button("Install as ISO###installpspiso"))
+            start_download_package(PspInstallMode::Iso);
+        ImGui::SetItemDefaultFocus();
+        if (ImGui::IsItemFocused())
+            ImGui::SetScrollY(0.0f);
 
-    if (_base_comppack)
+        if (_nopspemudrm_present)
+        {
+            if (ImGui::Button("Queue as PBP in LiveArea###installpsppbp"))
+                start_download_package(PspInstallMode::LiveAreaPbp);
+        }
+    }
+
+    if (is_vita_mode() && _base_comppack)
     {
         if (!_downloader->is_in_queue(CompPackBase, _item->titleid))
         {
-            if (ImGui::Button("Install base compatibility "
-                              "pack###installbasecomppack"))
+            if (ImGui::Button("Install base compatibility pack###installbasecomppack"))
                 start_download_comppack(false);
         }
         else
         {
-            if (ImGui::Button("Cancel base compatibility pack "
-                              "installation###installbasecomppack"))
+            if (ImGui::Button("Cancel base compatibility pack installation###installbasecomppack"))
                 cancel_download_comppacks(false);
         }
     }
-    if (_patch_comppack)
+    if (is_vita_mode() && _patch_comppack)
     {
         if (!_downloader->is_in_queue(CompPackPatch, _item->titleid))
         {
             if (ImGui::Button(fmt::format(
-                                      "Install compatibility pack "
-                                      "{}###installpatchcommppack",
+                                      "Install compatibility pack {}###installpatchcommppack",
                                       _patch_comppack->app_version)
                                       .c_str()))
                 start_download_comppack(true);
         }
         else
         {
-            if (ImGui::Button("Cancel patch compatibility pack "
-                              "installation###installpatchcommppack"))
+            if (ImGui::Button("Cancel patch compatibility pack installation###installpatchcommppack"))
                 cancel_download_comppacks(true);
         }
     }
 
-    auto tex = _image_fetcher.get_texture();
-    // Display game image
-    if (tex != nullptr)
+    if (_annotationDb)
     {
-        int tex_w = vita2d_texture_get_width(tex);
-        int tex_h = vita2d_texture_get_height(tex);
-        float tex_x = ImGui::GetWindowContentRegionMax().x - tex_w;
-        float tex_y = ImGui::GetWindowContentRegionMin().y;
-        ImGui::SetCursorPos(ImVec2(tex_x, tex_y));
-        ImGui::Image(tex, ImVec2(tex_w, tex_h));
+        if (_ime_active && pkgi_dialog_input_update())
+        {
+            pkgi_dialog_input_get_text(_comment_buf, sizeof(_comment_buf));
+            _annotation.comment = _comment_buf;
+            _annotationDb->set(_item->titleid, _annotation);
+            _item->user_comment = _annotation.comment;
+            _ime_active = false;
+        }
+
+        ImGui::Separator();
+        ImGui::Text("Personal Notes");
+        ImGui::Spacing();
+
+        // ── Flag — compact cycling selector  [ < ]  [label]  [ > ] ──────────
+        {
+            auto cycle = [&](int delta)
+            {
+                int fi = (static_cast<int>(_annotation.flag) + delta +
+                          UserFlagCount) %
+                         UserFlagCount;
+                _annotation.flag = static_cast<UserFlag>(fi);
+                _annotationDb->set(_item->titleid, _annotation);
+                _item->user_flag = _annotation.flag;
+            };
+
+            ImGui::Text("Flag:");
+            ImGui::SameLine();
+
+            if (ImGui::Button("< ##flagprev"))
+                cycle(-1);
+
+            ImGui::SameLine();
+
+            // Centre label button — clicking also cycles forward
+            const bool active = (_annotation.flag != UserFlag::None);
+            if (active)
+                ImGui::PushStyleColor(
+                        ImGuiCol_Button, ImVec4(0.2f, 0.6f, 0.2f, 1.0f));
+            // Fixed width so the window doesn't shift as text changes
+            if (ImGui::Button(
+                        fmt::format(
+                                "{:<18}###flaglabel",
+                                user_flag_label(_annotation.flag))
+                                .c_str(),
+                        ImVec2(180.f, 0)))
+                cycle(+1);
+            if (active)
+                ImGui::PopStyleColor();
+
+            ImGui::SameLine();
+            if (ImGui::Button("> ##flagnext"))
+                cycle(+1);
+        }
+
+        ImGui::Spacing();
+        ImGui::Text("Comment:");
+        ImGui::TextWrapped(
+                "%s",
+                _annotation.comment.empty() ? "(no comment)"
+                                            : _annotation.comment.c_str());
+        ImGui::Spacing();
+        if (ImGui::Button("Edit Comment"))
+        {
+            pkgi_dialog_input_text("Comment", _comment_buf);
+            _ime_active = true;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Clear Notes"))
+        {
+            _annotationDb->remove(_item->titleid);
+            _annotation = {};
+            _comment_buf[0] = '\0';
+            _item->user_flag = UserFlag::None;
+            _item->user_comment.clear();
+            _ime_active = false;
+        }
     }
 
     ImGui::End();
@@ -240,29 +522,48 @@ void GameView::printDiagnostic()
 
 std::string GameView::get_min_system_version()
 {
-    auto const patchInfo = _patch_info_fetcher.get_patch_info();
+    if (!_patch_info_fetcher)
+        return _item->fw_version;
+
+    auto const patchInfo = _patch_info_fetcher->get_patch_info();
     if (patchInfo)
         return patchInfo->fw_version;
     else
         return _item->fw_version;
 }
 
+bool GameView::is_vita_mode() const
+{
+    return _mode == ModeGames;
+}
+
 void GameView::refresh()
 {
-    LOGF("refreshing gameview");
-    _refood_present = pkgi_is_module_present("ref00d");
-    _0syscall6_present = pkgi_is_module_present("0syscall6");
-    _game_version = pkgi_get_game_version(_item->titleid);
-    _comppack_versions = pkgi_get_comppack_versions(_item->titleid);
+    LOGF("Refreshing game view");
+    if (is_vita_mode())
+    {
+        _refood_present = pkgi_is_module_present("ref00d");
+        _0syscall6_present = pkgi_is_module_present("0syscall6");
+        _game_version = pkgi_get_game_version(_item->titleid);
+        _comppack_versions = pkgi_get_comppack_versions(_item->titleid);
+    }
+    else
+    {
+        _refood_present = false;
+        _0syscall6_present = false;
+        _nopspemudrm_present = pkgi_is_module_present("NoPspEmuDrm_kern");
+        _game_version.clear();
+        _comppack_versions = {};
+    }
 }
 
 
-void GameView::do_download() {
-    pkgi_start_download(*_downloader, *_item);
+void GameView::do_download(PspInstallMode psp_install_mode) {
+    pkgi_start_download(*_downloader, *_item, psp_install_mode);
     _item->presence = PresenceUnknown;
 }
 
-void GameView::start_download_package()
+void GameView::start_download_package(PspInstallMode psp_install_mode)
 {
     if (_item->presence == PresenceInstalled)
     {
@@ -273,11 +574,11 @@ void GameView::start_download_package()
                 "Would you like to redownload it?",
                 _item->name)
                 .c_str(),
-        {{"Redownload.", [this] { this->do_download(); }},
+        {{"Redownload.", [this, psp_install_mode] { this->do_download(psp_install_mode); }},
          {"Dont Redownload.", [] {} }});
         return;
     }
-    this->do_download();
+    this->do_download(psp_install_mode);
 }
 
 void GameView::cancel_download_package()

--- a/src/gameview.cpp
+++ b/src/gameview.cpp
@@ -48,6 +48,9 @@ constexpr ThumbSize kThumbSizes[] = {
 };
 constexpr int kThumbSizeCount = 4;
 
+// Highlight border color when a panel is "focused" at View level
+constexpr ImU32 kFocusBorderCol = IM_COL32(90, 160, 255, 220);
+
 const char* presence_label(DbPresence presence)
 {
     switch (presence)
@@ -136,7 +139,13 @@ GameView::GameView(
     _comment_buf[sizeof(_comment_buf) - 1] = '\0';
 
     if (is_vita_mode())
+    {
         _patch_info_fetcher = std::make_unique<PatchInfoFetcher>(item->titleid);
+        _description_fetcher =
+                std::make_unique<DescriptionFetcher>(item);
+        _screenshot_fetcher =
+                std::make_unique<ScreenshotFetcher>(config, item);
+    }
 
     refresh();
 }
@@ -158,158 +167,410 @@ void GameView::render()
                     ImGuiWindowFlags_NoCollapse |
                     ImGuiWindowFlags_NoSavedSettings);
 
+    // ── Layout constants ─────────────────────────────────────────────────────
+    const int tsz = std::max(0, std::min(
+            _config->thumbnail_size, kThumbSizeCount - 1));
+    const float cover_w  = kThumbSizes[tsz].w;
+    const float cover_h  = kThumbSizes[tsz].h;
+    const bool  two_col  = (cover_w > 0.f);
+
+    // Reserve one line at the bottom for hint text
+    const float hint_h  = ImGui::GetFrameHeightWithSpacing();
+    const float avail_h  = ImGui::GetContentRegionAvail().y - hint_h;
+    const float col_gap  = ImGui::GetStyle().ItemSpacing.x;
+    const float left_w   = two_col ? (cover_w + 4.f) : 0.f;
+    const float right_w  = ImGui::GetContentRegionAvail().x
+                           - (two_col ? left_w + col_gap : 0.f);
+
+    // ── View-level D-pad: switch focused panel ────────────────────────────────
+    if (two_col && _focus_level == FocusLevel::View)
     {
-        const int tsz = std::max(0, std::min(
-                _config->thumbnail_size, kThumbSizeCount - 1));
-        const float kImagePanelW = kThumbSizes[tsz].w;
-        const float kImagePanelH = kThumbSizes[tsz].h;
-        auto* thumb_tex = _image_fetcher.get_texture();
-        const auto image_status = _image_fetcher.get_status();
-
-        if (kImagePanelW > 0.f)
+        if (ImGui::IsKeyPressed(ImGuiKey_GamepadDpadLeft, false))
+            _focused_panel = FocusPanel::Left;
+        if (ImGui::IsKeyPressed(ImGuiKey_GamepadDpadRight, false))
+            _focused_panel = FocusPanel::Right;
+        // X / face-down at View level enters the selected panel
+        if (ImGui::IsKeyPressed(ImGuiKey_GamepadFaceDown, false))
         {
-            const ImGuiStyle& style = ImGui::GetStyle();
-            ImVec2 win_pos = ImGui::GetWindowPos();
-            const float title_bar_h = ImGui::GetFrameHeight();
-            ImVec2 panel_min(
-                    win_pos.x + (float)GameViewWidth
-                            - style.WindowPadding.x - kImagePanelW,
-                    win_pos.y + title_bar_h + style.WindowPadding.y);
-            ImVec2 panel_max(
-                    panel_min.x + kImagePanelW,
-                    panel_min.y + kImagePanelH);
-
-            ImDrawList* dl = ImGui::GetForegroundDrawList();
-            dl->AddRectFilled(panel_min, panel_max, IM_COL32(20, 20, 20, 230), 3.f);
-            dl->AddRect(panel_min, panel_max, IM_COL32(110, 110, 110, 255), 3.f);
-
-            if (thumb_tex)
-            {
-                float tw = static_cast<float>(vita2d_texture_get_width(thumb_tex));
-                float th = static_cast<float>(vita2d_texture_get_height(thumb_tex));
-                const float inner_w = kImagePanelW - 6.f;
-                const float inner_h = kImagePanelH - 6.f;
-                if (tw > inner_w) { th = th * inner_w / tw; tw = inner_w; }
-                if (th > inner_h) { tw = tw * inner_h / th; th = inner_h; }
-                // Top-align: centre horizontally, pin to top of inner area
-                ImVec2 img_min(
-                        panel_min.x + (kImagePanelW - tw) * 0.5f,
-                        panel_min.y + 3.f);
-                ImVec2 img_max(img_min.x + tw, img_min.y + th);
-                dl->AddImage((ImTextureID)thumb_tex, img_min, img_max);
-            }
-            else
-            {
-                if (image_status == ImageFetcher::Status::Downloading)
-                {
-                    draw_centered_status_text(
-                            dl,
-                            panel_min,
-                            kImagePanelW,
-                            kImagePanelH,
-                            "Downloading",
-                            "cover",
-                            IM_COL32(180, 190, 220, 220));
-                }
-                else if (image_status == ImageFetcher::Status::Error)
-                {
-                    draw_centered_status_text(
-                            dl,
-                            panel_min,
-                            kImagePanelW,
-                            kImagePanelH,
-                            "Download error",
-                            "no image available",
-                            IM_COL32(210, 150, 150, 220));
-                }
-            }
+            _focus_level   = FocusLevel::Panel;
+            _request_focus = true;
         }
     }
 
+    // ── Helper: draw a focus border around a screen rect ─────────────────────
+    auto draw_focus_border = [](ImVec2 min, ImVec2 max)
     {
-        const int tsz = std::max(0, std::min(
-                _config->thumbnail_size, kThumbSizeCount - 1));
-        const float panelW = kThumbSizes[tsz].w;
-        ImGui::PushTextWrapPos(
-                panelW > 0.f
-                ? (float)GameViewWidth
-                        - ImGui::GetStyle().WindowPadding.x
-                        - panelW
-                        - ImGui::GetStyle().ItemSpacing.x
-                : 0.f);
-    }
+        ImGui::GetWindowDrawList()->AddRect(
+                min, max, kFocusBorderCol, 4.f, 0, 2.f);
+    };
 
-    if (is_vita_mode())
+    // ── LEFT COLUMN: cover + screenshots (only when two_col) ─────────────────
+    if (two_col)
     {
-        ImGui::Text(fmt::format("Firmware version: {}", pkgi_get_system_version()).c_str());
-        ImGui::Text(fmt::format("Required firmware version: {}", get_min_system_version()).c_str());
-        ImGui::Text(" ");
-        ImGui::Text(fmt::format(
-                            "Installed game version: {}",
-                            _game_version.empty() ? "not installed" : _game_version)
-                            .c_str());
-        if (_comppack_versions.present && _comppack_versions.base.empty() &&
-            _comppack_versions.patch.empty())
+        const bool lc_active = (_focus_level == FocusLevel::Panel &&
+                                _focused_panel == FocusPanel::Left) ||
+                               (_focus_level == FocusLevel::SubItem &&
+                                _focused_panel == FocusPanel::Left);
+        const bool lc_hinted = (_focus_level == FocusLevel::View &&
+                                _focused_panel == FocusPanel::Left);
+
+        // Seize ImGui focus for this child when requested
+        if (_request_focus && _focused_panel == FocusPanel::Left &&
+            _focus_level == FocusLevel::Panel)
         {
-            ImGui::Text("Installed compatibility pack: unknown version");
+            ImGui::SetNextWindowFocus();
+            _request_focus = false;
+        }
+
+        ImVec2 lc_screen_min = ImGui::GetCursorScreenPos();
+
+        ImGui::BeginChild(
+                "##lc",
+                ImVec2(left_w, avail_h),
+                false,
+                (lc_active ? ImGuiWindowFlags_None
+                           : ImGuiWindowFlags_NoNav) |
+                        ImGuiWindowFlags_NoScrollbar |
+                        ImGuiWindowFlags_NoScrollWithMouse);
+
+        auto* thumb_tex     = _image_fetcher.get_texture();
+        const auto img_stat = _image_fetcher.get_status();
+        ImDrawList* ldl     = ImGui::GetWindowDrawList();
+
+        if (thumb_tex)
+        {
+            float tw = static_cast<float>(vita2d_texture_get_width(thumb_tex));
+            float th = static_cast<float>(vita2d_texture_get_height(thumb_tex));
+            if (tw > cover_w) { th = th * cover_w / tw; tw = cover_w; }
+            if (th > cover_h) { tw = tw * cover_h / th; th = cover_h; }
+            const float ox = (cover_w - tw) * 0.5f;
+            if (ox > 0.f)
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ox);
+            ImGui::Image(reinterpret_cast<ImTextureID>(thumb_tex),
+                         ImVec2(tw, th));
         }
         else
         {
-            ImGui::Text(fmt::format(
-                                "Installed base compatibility pack: {}",
-                                _comppack_versions.base.empty() ? "no" : "yes")
-                                .c_str());
-            ImGui::Text(fmt::format(
-                                "Installed patch compatibility pack version: {}",
-                                _comppack_versions.patch.empty() ? "none"
-                                                                 : _comppack_versions.patch)
-                                .c_str());
+            ImVec2 pm = ImGui::GetCursorScreenPos();
+            ImGui::Dummy(ImVec2(cover_w, cover_h));
+            ldl->AddRectFilled(
+                    pm,
+                    {pm.x + cover_w, pm.y + cover_h},
+                    IM_COL32(18, 22, 40, 220),
+                    4.f);
+            ldl->AddRect(
+                    pm,
+                    {pm.x + cover_w, pm.y + cover_h},
+                    IM_COL32(70, 80, 110, 255),
+                    4.f);
+            const char* l1 =
+                    (img_stat == ImageFetcher::Status::Downloading)
+                    ? "Downloading"
+                    : "No image";
+            const char* l2 =
+                    (img_stat == ImageFetcher::Status::Downloading)
+                    ? "cover..."
+                    : nullptr;
+            draw_centered_status_text(
+                    ldl, pm, cover_w, cover_h, l1, l2,
+                    IM_COL32(160, 170, 200, 200));
         }
-        ImGui::Text(" ");
+
+        // Screenshots — vita mode only
+        if (is_vita_mode() && _screenshot_fetcher)
+        {
+            ImGui::Spacing();
+            ImGui::TextDisabled("Screenshots");
+            ImGui::Spacing();
+
+            // Fit 3 screenshots across cover_w with small gaps
+            const float ss_gap = 4.f;
+            const float ss_w   = (cover_w - 2.f * ss_gap) / 3.f;
+            const float ss_h   = ss_w * 9.f / 16.f;
+
+            int shown = 0;
+            for (int i = 0;
+                 i < ScreenshotFetcher::MAX_SCREENSHOTS && shown < 3;
+                 ++i)
+            {
+                const auto ss_st =
+                        _screenshot_fetcher->get_status(i);
+                auto* ss_tx =
+                        _screenshot_fetcher->get_texture(i);
+
+                // Stop rendering once we hit a non-cached 404 slot
+                if (ss_st == ScreenshotFetcher::Status::Error && !ss_tx)
+                    break;
+
+                if (shown > 0)
+                    ImGui::SameLine(0, ss_gap);
+
+                if (ss_tx)
+                {
+                    const bool sel = (_selected_screenshot == i);
+                    if (sel)
+                        ImGui::PushStyleColor(
+                                ImGuiCol_Border,
+                                ImVec4(0.5f, 0.8f, 1.f, 1.f));
+                    if (ImGui::ImageButton(
+                                fmt::format("##ss{}", i).c_str(),
+                                reinterpret_cast<ImTextureID>(ss_tx),
+                                ImVec2(ss_w, ss_h)))
+                        _selected_screenshot = i;
+                    if (sel)
+                        ImGui::PopStyleColor();
+                }
+                else
+                {
+                    // Loading placeholder
+                    ImVec2 pm2 = ImGui::GetCursorScreenPos();
+                    ImGui::Dummy(ImVec2(ss_w, ss_h));
+                    ldl->AddRectFilled(
+                            pm2,
+                            {pm2.x + ss_w, pm2.y + ss_h},
+                            IM_COL32(15, 18, 32, 200),
+                            2.f);
+                    ldl->AddRect(
+                            pm2,
+                            {pm2.x + ss_w, pm2.y + ss_h},
+                            IM_COL32(55, 65, 90, 255),
+                            2.f);
+                }
+                ++shown;
+            }
+        }
+
+        ImGui::EndChild(); // ##lc
+
+        // Draw focus / hover border over the left column area
+        ImVec2 lc_screen_max{
+                lc_screen_min.x + left_w,
+                lc_screen_min.y + avail_h};
+        if (lc_active || lc_hinted)
+            draw_focus_border(lc_screen_min, lc_screen_max);
+
+        ImGui::SameLine(0, col_gap);
+    }
+
+    // ── RIGHT COLUMN (or full-width single column) ────────────────────────────
+    const bool rc_active = !two_col ||
+                           (_focus_level == FocusLevel::Panel &&
+                            _focused_panel == FocusPanel::Right) ||
+                           (_focus_level == FocusLevel::SubItem &&
+                            _focused_panel == FocusPanel::Right);
+    const bool rc_hinted = two_col &&
+                           _focus_level == FocusLevel::View &&
+                           _focused_panel == FocusPanel::Right;
+
+    if (_request_focus && (!two_col || _focused_panel == FocusPanel::Right) &&
+        _focus_level == FocusLevel::Panel)
+    {
+        ImGui::SetNextWindowFocus();
+        _request_focus = false;
+    }
+
+    ImVec2 rc_screen_min = ImGui::GetCursorScreenPos();
+
+    ImGui::BeginChild(
+            "##rc",
+            ImVec2(right_w, avail_h),
+            false,
+            (rc_active ? ImGuiWindowFlags_None : ImGuiWindowFlags_NoNav));
+
+    // Content width inside the child (accounts for padding / scrollbar)
+    const float rc_w = ImGui::GetContentRegionAvail().x;
+    ImGui::PushTextWrapPos(0.f); // wrap at right edge of this child
+
+    if (is_vita_mode())
+    {
+        // ── Metadata rows ────────────────────────────────────────────────────
+        // Helper: label in dim text, value right-aligned at a fixed x offset.
+        const float label_x = 160.f;
+        auto row = [&](const char* label,
+                       const char* value,
+                       ImVec4 col = ImVec4(-1.f, -1.f, -1.f, -1.f))
+        {
+            ImGui::TextDisabled("%s", label);
+            ImGui::SameLine(label_x);
+            if (col.x >= 0.f)
+                ImGui::TextColored(col, "%s", value);
+            else
+                ImGui::Text("%s", value);
+        };
+
+        row("Title ID:", _item->titleid.c_str());
+
+        const auto sys_ver = pkgi_get_system_version();
+        const auto min_ver = get_min_system_version();
+        const bool fw_ok   = !min_ver.empty() && sys_ver >= min_ver;
+
+        row("Min firmware:",
+            min_ver.empty() ? "unknown" : min_ver.c_str());
+        row("System firmware:",
+            sys_ver.c_str(),
+            fw_ok ? ImVec4(0.3f, 1.f, 0.5f, 1.f)
+                  : ImVec4(1.f, 0.35f, 0.35f, 1.f));
+
+        const bool installed = !_game_version.empty();
+        row("Installed version:",
+            installed ? _game_version.c_str() : "not installed",
+            installed ? ImVec4(0.3f, 1.f, 0.5f, 1.f)
+                      : ImVec4(1.f, 0.88f, 0.25f, 1.f));
+
+        if (_comppack_versions.present &&
+            _comppack_versions.base.empty() &&
+            _comppack_versions.patch.empty())
+        {
+            ImGui::TextColored(
+                    ImVec4(1.f, 0.9f, 0.2f, 1.f),
+                    "Compat pack: installed (unknown version)");
+        }
+        else
+        {
+            row("Base compat pack:",
+                _comppack_versions.base.empty() ? "not installed" : "installed");
+            if (!_comppack_versions.patch.empty())
+                row("Patch compat pack:", _comppack_versions.patch.c_str());
+        }
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        // ── Description ──────────────────────────────────────────────────────
+        if (_description_fetcher &&
+            _description_fetcher->get_status() ==
+                    DescriptionFetcher::Status::Found)
+        {
+            const auto desc = _description_fetcher->get_description();
+            ImGui::TextDisabled("Description");
+            ImGui::Spacing();
+
+            // Sub-item focus: let description scroll area receive ImGui nav
+            const bool desc_active =
+                    (_focus_level == FocusLevel::SubItem &&
+                     _focused_panel == FocusPanel::Right);
+
+            if (_request_focus && desc_active)
+            {
+                ImGui::SetNextWindowFocus();
+                _request_focus = false;
+            }
+
+            ImGui::PushStyleColor(
+                    ImGuiCol_ChildBg, ImVec4(0.05f, 0.09f, 0.18f, 1.f));
+            ImGui::BeginChild(
+                    "##desc", ImVec2(rc_w, 80.f), true,
+                    desc_active ? ImGuiWindowFlags_None
+                                : ImGuiWindowFlags_NoNav);
+            ImGui::PushTextWrapPos(0.f);
+            ImGui::TextUnformatted(desc.c_str());
+            ImGui::PopTextWrapPos();
+            ImGui::EndChild();
+            ImGui::PopStyleColor();
+
+            // "Enter scroll" button — navigable in Panel level, enters SubItem
+            if (!desc_active)
+            {
+                if (ImGui::SmallButton("Scroll description ###descscroll"))
+                {
+                    _focus_level   = FocusLevel::SubItem;
+                    _request_focus = true;
+                }
+            }
+
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+        }
+
+        // ── Diagnostic ───────────────────────────────────────────────────────
         printDiagnostic();
-        ImGui::Text(" ");
+        ImGui::Spacing();
+
+        // ── Action buttons ───────────────────────────────────────────────────
+        if (_patch_info_fetcher &&
+            _patch_info_fetcher->get_status() ==
+                    PatchInfoFetcher::Status::Found)
+        {
+            if (ImGui::Button("Install game and patch###installgame"))
+                start_download_package();
+        }
+        else
+        {
+            if (ImGui::Button("Install game###installgame"))
+                start_download_package();
+        }
+        ImGui::SetItemDefaultFocus();
+        if (ImGui::IsItemFocused())
+            ImGui::SetScrollY(0.0f);
+
+        if (_base_comppack)
+        {
+            ImGui::SameLine();
+            if (!_downloader->is_in_queue(CompPackBase, _item->titleid))
+            {
+                if (ImGui::Button(
+                            "Install base compat pack###installbasecomppack"))
+                    start_download_comppack(false);
+            }
+            else
+            {
+                if (ImGui::Button(
+                            "Cancel base compat pack###installbasecomppack"))
+                    cancel_download_comppacks(false);
+            }
+        }
+        if (_patch_comppack)
+        {
+            ImGui::SameLine();
+            if (!_downloader->is_in_queue(CompPackPatch, _item->titleid))
+            {
+                if (ImGui::Button(fmt::format(
+                                          "Install patch compat {}###installpatchcommppack",
+                                          _patch_comppack->app_version)
+                                          .c_str()))
+                    start_download_comppack(true);
+            }
+            else
+            {
+                if (ImGui::Button(
+                            "Cancel patch compat###installpatchcommppack"))
+                    cancel_download_comppacks(true);
+            }
+        }
     }
     else
-    {        
-        ImGui::Text(fmt::format("Content ID: {}",
-                                _item->content.empty() ? "unknown" : _item->content).c_str());
-        ImGui::Text(fmt::format("Package size: {}", friendly_size(_item->size)).c_str());
-        ImGui::Text(fmt::format("Last update: {}",
-                                _item->date.empty() ? "unknown" : _item->date).c_str());
-        ImGui::Text(" ");
+    {
+        // ── PSP / non-vita mode ──────────────────────────────────────────────
+        ImGui::Text(fmt::format(
+                            "Content ID: {}",
+                            _item->content.empty() ? "unknown"
+                                                   : _item->content)
+                            .c_str());
+        ImGui::Text(fmt::format("Package size: {}", friendly_size(_item->size))
+                            .c_str());
+        ImGui::Text(fmt::format(
+                            "Last update: {}",
+                            _item->date.empty() ? "unknown" : _item->date)
+                            .c_str());
+        ImGui::Spacing();
+
         ImGui::Text("Diagnostic:");
-        ImGui::Text(fmt::format("- Status: {}", presence_label(_item->presence)).c_str());
-        ImGui::Text(fmt::format("- NoPspEmuDrm kernel plugin: {}",
-                                _nopspemudrm_present ? "present" : "not detected").c_str());
+        ImGui::Text(fmt::format("- Status: {}",
+                                presence_label(_item->presence))
+                            .c_str());
+        ImGui::Text(fmt::format(
+                            "- NoPspEmuDrm kernel plugin: {}",
+                            _nopspemudrm_present ? "present" : "not detected")
+                            .c_str());
         ImGui::Text("- Install as ISO: available");
         if (_nopspemudrm_present)
             ImGui::Text("- LiveArea PBP queue: available");
         else
             ImGui::Text("- LiveArea PBP queue: unavailable without plugin");
-        ImGui::Text(" ");
-    }
+        ImGui::Spacing();
 
-    ImGui::PopTextWrapPos();
-
-    if (is_vita_mode() && _patch_info_fetcher &&
-        _patch_info_fetcher->get_status() == PatchInfoFetcher::Status::Found)
-    {
-        if (ImGui::Button("Install game and patch###installgame"))
-            start_download_package();
-        ImGui::SetItemDefaultFocus();
-        if (ImGui::IsItemFocused())
-            ImGui::SetScrollY(0.0f);
-    }
-    else if (is_vita_mode())
-    {
-        if (ImGui::Button("Install game###installgame"))
-            start_download_package();
-        ImGui::SetItemDefaultFocus();
-        if (ImGui::IsItemFocused())
-            ImGui::SetScrollY(0.0f);
-    }
-    else
-    {
         if (ImGui::Button("Install as ISO###installpspiso"))
             start_download_package(PspInstallMode::Iso);
         ImGui::SetItemDefaultFocus();
@@ -323,36 +584,7 @@ void GameView::render()
         }
     }
 
-    if (is_vita_mode() && _base_comppack)
-    {
-        if (!_downloader->is_in_queue(CompPackBase, _item->titleid))
-        {
-            if (ImGui::Button("Install base compatibility pack###installbasecomppack"))
-                start_download_comppack(false);
-        }
-        else
-        {
-            if (ImGui::Button("Cancel base compatibility pack installation###installbasecomppack"))
-                cancel_download_comppacks(false);
-        }
-    }
-    if (is_vita_mode() && _patch_comppack)
-    {
-        if (!_downloader->is_in_queue(CompPackPatch, _item->titleid))
-        {
-            if (ImGui::Button(fmt::format(
-                                      "Install compatibility pack {}###installpatchcommppack",
-                                      _patch_comppack->app_version)
-                                      .c_str()))
-                start_download_comppack(true);
-        }
-        else
-        {
-            if (ImGui::Button("Cancel patch compatibility pack installation###installpatchcommppack"))
-                cancel_download_comppacks(true);
-        }
-    }
-
+    // ── Annotations (both modes) ─────────────────────────────────────────────
     if (_annotationDb)
     {
         if (_ime_active && pkgi_dialog_input_update())
@@ -368,7 +600,7 @@ void GameView::render()
         ImGui::Text("Personal Notes");
         ImGui::Spacing();
 
-        // ── Flag — compact cycling selector  [ < ]  [label]  [ > ] ──────────
+        // Flag — compact cycling selector  [ < ]  [label]  [ > ]
         {
             auto cycle = [&](int delta)
             {
@@ -388,12 +620,10 @@ void GameView::render()
 
             ImGui::SameLine();
 
-            // Centre label button — clicking also cycles forward
             const bool active = (_annotation.flag != UserFlag::None);
             if (active)
                 ImGui::PushStyleColor(
                         ImGuiCol_Button, ImVec4(0.2f, 0.6f, 0.2f, 1.0f));
-            // Fixed width so the window doesn't shift as text changes
             if (ImGui::Button(
                         fmt::format(
                                 "{:<18}###flaglabel",
@@ -433,7 +663,57 @@ void GameView::render()
         }
     }
 
+    ImGui::PopTextWrapPos();
+    ImGui::EndChild(); // ##rc
+
+    // Draw focus border around the right column
+    if (rc_active || rc_hinted)
+    {
+        ImVec2 rc_screen_max{
+                rc_screen_min.x + right_w,
+                rc_screen_min.y + avail_h};
+        draw_focus_border(rc_screen_min, rc_screen_max);
+    }
+
+    // ── Hint bar ─────────────────────────────────────────────────────────────
+    ImGui::Spacing();
+    switch (_focus_level)
+    {
+    case FocusLevel::View:
+        if (two_col)
+            ImGui::TextDisabled(
+                    "  [<][>] Switch panel   [X] Enter panel   [O] Close");
+        else
+            ImGui::TextDisabled("  [O] Close");
+        break;
+    case FocusLevel::Panel:
+        ImGui::TextDisabled(
+                "  [X] Confirm   [O] Back to panel select");
+        break;
+    case FocusLevel::SubItem:
+        ImGui::TextDisabled(
+                "  [^][v] Scroll   [O] Back");
+        break;
+    }
+
     ImGui::End();
+}
+
+bool GameView::handle_cancel()
+{
+    switch (_focus_level)
+    {
+    case FocusLevel::SubItem:
+        _focus_level   = FocusLevel::Panel;
+        _request_focus = true;
+        return true;
+    case FocusLevel::Panel:
+        _focus_level = FocusLevel::View;
+        return true;
+    case FocusLevel::View:
+        return false; // caller (pkgi.cpp) will call close()
+    }
+    return false;
 }
 
 static const auto Red = ImVec4(1.0f, 0.2f, 0.2f, 1.0f);

--- a/src/gameview.cpp
+++ b/src/gameview.cpp
@@ -371,11 +371,14 @@ void GameView::render()
 
     ImVec2 rc_screen_min = ImGui::GetCursorScreenPos();
 
+    ImGui::PushStyleVar(
+            ImGuiStyleVar_WindowPadding, ImVec2(4.f, 2.f));
     ImGui::BeginChild(
             "##rc",
             ImVec2(right_w, avail_h),
             false,
             (rc_active ? ImGuiWindowFlags_None : ImGuiWindowFlags_NoNav));
+    ImGui::PopStyleVar();
 
     // Content width inside the child (accounts for padding / scrollbar)
     const float rc_w = ImGui::GetContentRegionAvail().x;
@@ -384,8 +387,8 @@ void GameView::render()
     if (is_vita_mode())
     {
         // ── Metadata rows ────────────────────────────────────────────────────
-        // Helper: label in dim text, value right-aligned at a fixed x offset.
-        const float label_x = 160.f;
+        // Helper: label in dim text, value at a fixed x offset.
+        const float label_x = 190.f;
         auto row = [&](const char* label,
                        const char* value,
                        ImVec4 col = ImVec4(-1.f, -1.f, -1.f, -1.f))
@@ -398,24 +401,52 @@ void GameView::render()
                 ImGui::Text("%s", value);
         };
 
-        row("Title ID:", _item->titleid.c_str());
-
         const auto sys_ver = pkgi_get_system_version();
         const auto min_ver = get_min_system_version();
         const bool fw_ok   = !min_ver.empty() && sys_ver >= min_ver;
 
-        row("Min firmware:",
-            min_ver.empty() ? "unknown" : min_ver.c_str());
-        row("System firmware:",
-            sys_ver.c_str(),
-            fw_ok ? ImVec4(0.3f, 1.f, 0.5f, 1.f)
-                  : ImVec4(1.f, 0.35f, 0.35f, 1.f));
+        // Single combined firmware line: "Required: X.XX (current: Y.YY)"
+        {
+            const std::string req_str =
+                    min_ver.empty() ? "unknown" : min_ver;
+            const std::string fw_line =
+                    fmt::format("{} (current: {})", req_str, sys_ver);
+            row("Required firmware:",
+                fw_line.c_str(),
+                fw_ok ? ImVec4(0.3f, 1.f, 0.5f, 1.f)
+                      : ImVec4(1.f, 0.35f, 0.35f, 1.f));
+        }
 
         const bool installed = !_game_version.empty();
-        row("Installed version:",
-            installed ? _game_version.c_str() : "not installed",
-            installed ? ImVec4(0.3f, 1.f, 0.5f, 1.f)
-                      : ImVec4(1.f, 0.88f, 0.25f, 1.f));
+
+        // Installed version + base compat pack on one line
+        {
+            ImGui::TextDisabled("Installed version:");
+            ImGui::SameLine(label_x);
+            if (installed)
+                ImGui::TextColored(
+                        ImVec4(0.3f, 1.f, 0.5f, 1.f),
+                        "%s",
+                        _game_version.c_str());
+            else
+                ImGui::TextColored(
+                        ImVec4(1.f, 0.88f, 0.25f, 1.f), "not installed");
+
+            // Base compat pack status on the same line if there is info
+            if (_comppack_versions.present ||
+                !_comppack_versions.base.empty())
+            {
+                ImGui::SameLine();
+                ImGui::TextDisabled("  Base cp:");
+                ImGui::SameLine();
+                if (_comppack_versions.base.empty())
+                    ImGui::TextColored(
+                            ImVec4(1.f, 0.88f, 0.25f, 1.f), "no");
+                else
+                    ImGui::TextColored(
+                            ImVec4(0.3f, 1.f, 0.5f, 1.f), "yes");
+            }
+        }
 
         if (_comppack_versions.present &&
             _comppack_versions.base.empty() &&
@@ -425,12 +456,9 @@ void GameView::render()
                     ImVec4(1.f, 0.9f, 0.2f, 1.f),
                     "Compat pack: installed (unknown version)");
         }
-        else
+        else if (!_comppack_versions.patch.empty())
         {
-            row("Base compat pack:",
-                _comppack_versions.base.empty() ? "not installed" : "installed");
-            if (!_comppack_versions.patch.empty())
-                row("Patch compat pack:", _comppack_versions.patch.c_str());
+            row("Patch compat pack:", _comppack_versions.patch.c_str());
         }
 
         ImGui::Spacing();
@@ -443,14 +471,36 @@ void GameView::render()
                     DescriptionFetcher::Status::Found)
         {
             const auto desc = _description_fetcher->get_description();
-            ImGui::TextDisabled("Description");
+
+            // At Panel level: "Description" is a selectable — pressing X
+            // on it enters SubItem (scroll) mode.  At other levels it is a
+            // plain header.
+            const bool at_panel_right =
+                    (_focus_level == FocusLevel::Panel &&
+                     _focused_panel == FocusPanel::Right);
+            const bool desc_active =
+                    (_focus_level == FocusLevel::SubItem &&
+                     _focused_panel == FocusPanel::Right &&
+                     _subitem_target == SubItemTarget::Description);
+
+            if (at_panel_right)
+            {
+                if (ImGui::Selectable(
+                            "Description###desc_hdr", false,
+                            ImGuiSelectableFlags_None))
+                {
+                    _subitem_target = SubItemTarget::Description;
+                    _focus_level   = FocusLevel::SubItem;
+                    _request_focus = true;
+                }
+            }
+            else
+            {
+                ImGui::TextDisabled("Description");
+            }
             ImGui::Spacing();
 
             // Sub-item focus: let description scroll area receive ImGui nav
-            const bool desc_active =
-                    (_focus_level == FocusLevel::SubItem &&
-                     _focused_panel == FocusPanel::Right);
-
             if (_request_focus && desc_active)
             {
                 ImGui::SetNextWindowFocus();
@@ -468,16 +518,6 @@ void GameView::render()
             ImGui::PopTextWrapPos();
             ImGui::EndChild();
             ImGui::PopStyleColor();
-
-            // "Enter scroll" button — navigable in Panel level, enters SubItem
-            if (!desc_active)
-            {
-                if (ImGui::SmallButton("Scroll description ###descscroll"))
-                {
-                    _focus_level   = FocusLevel::SubItem;
-                    _request_focus = true;
-                }
-            }
 
             ImGui::Spacing();
             ImGui::Separator();
@@ -640,11 +680,58 @@ void GameView::render()
         }
 
         ImGui::Spacing();
-        ImGui::Text("Comment:");
-        ImGui::TextWrapped(
-                "%s",
-                _annotation.comment.empty() ? "(no comment)"
-                                            : _annotation.comment.c_str());
+
+        // Comment field: shown as a scrollable blue box, like description.
+        // At Panel level: "Comment" header is a selectable to enter scroll.
+        {
+            const bool at_panel_right =
+                    (_focus_level == FocusLevel::Panel &&
+                     _focused_panel == FocusPanel::Right);
+            const bool comment_active =
+                    (_focus_level == FocusLevel::SubItem &&
+                     _focused_panel == FocusPanel::Right &&
+                     _subitem_target == SubItemTarget::Comment);
+
+            if (at_panel_right && !_annotation.comment.empty())
+            {
+                if (ImGui::Selectable(
+                            "Comment###comment_hdr", false,
+                            ImGuiSelectableFlags_None))
+                {
+                    _subitem_target = SubItemTarget::Comment;
+                    _focus_level   = FocusLevel::SubItem;
+                    _request_focus = true;
+                }
+            }
+            else
+            {
+                ImGui::Text("Comment:");
+            }
+
+            if (_request_focus && comment_active)
+            {
+                ImGui::SetNextWindowFocus();
+                _request_focus = false;
+            }
+
+            ImGui::PushStyleColor(
+                    ImGuiCol_ChildBg, ImVec4(0.05f, 0.09f, 0.18f, 1.f));
+            ImGui::BeginChild(
+                    "##comment_box",
+                    ImVec2(rc_w, 60.f),
+                    true,
+                    comment_active ? ImGuiWindowFlags_None
+                                   : ImGuiWindowFlags_NoNav);
+            ImGui::PushTextWrapPos(0.f);
+            ImGui::TextUnformatted(
+                    _annotation.comment.empty()
+                            ? "(no comment)"
+                            : _annotation.comment.c_str());
+            ImGui::PopTextWrapPos();
+            ImGui::EndChild();
+            ImGui::PopStyleColor();
+        }
+
         ImGui::Spacing();
         if (ImGui::Button("Edit Comment"))
         {
@@ -688,7 +775,7 @@ void GameView::render()
         break;
     case FocusLevel::Panel:
         ImGui::TextDisabled(
-                "  [X] Confirm   [O] Back to panel select");
+                "  [X] Select / Enter scroll   [O] Back to panel select");
         break;
     case FocusLevel::SubItem:
         ImGui::TextDisabled(
@@ -796,8 +883,7 @@ void GameView::printDiagnostic()
         ok = false;
     }
 
-    if (ok)
-        ImGui::TextColored(Green, "All green");
+    (void)ok; // "All green" omitted — installed state is shown in metadata above
 }
 
 std::string GameView::get_min_system_version()

--- a/src/gameview.hpp
+++ b/src/gameview.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "annotationdb.hpp"
 #include "comppackdb.hpp"
 #include "config.hpp"
 #include "db.hpp"
@@ -8,17 +9,21 @@
 #include "install.hpp"
 #include "patchinfofetcher.hpp"
 
+#include <memory>
+
 #include <optional>
 
 class GameView
 {
 public:
     GameView(
+            Mode mode,
             const Config* config,
             Downloader* downloader,
             DbItem* item,
             std::optional<CompPackDatabase::Item> base_comppack,
-            std::optional<CompPackDatabase::Item> patch_comppack);
+            std::optional<CompPackDatabase::Item> patch_comppack,
+            AnnotationDatabase* annotationDb);
 
     const DbItem* get_item() const
     {
@@ -39,6 +44,7 @@ public:
     }
 
 private:
+    Mode _mode;
     const Config* _config;
     Downloader* _downloader;
 
@@ -46,20 +52,30 @@ private:
     std::optional<CompPackDatabase::Item> _base_comppack;
     std::optional<CompPackDatabase::Item> _patch_comppack;
 
-    bool _refood_present;
-    bool _0syscall6_present;
+    bool _refood_present{false};
+    bool _0syscall6_present{false};
+    bool _nopspemudrm_present{false};
     std::string _game_version;
     CompPackVersion _comppack_versions;
 
     bool _closed{false};
 
-    PatchInfoFetcher _patch_info_fetcher;
+    std::unique_ptr<PatchInfoFetcher> _patch_info_fetcher;
     ImageFetcher _image_fetcher;
 
+    // --- Annotation state ---
+    AnnotationDatabase* _annotationDb;
+    UserAnnotation      _annotation;       // working copy
+    char                _comment_buf[512]; // buffer for IME result
+    bool                _ime_active{false}; // true while virtual keyboard is open
+    // ------------------------
+
     std::string get_min_system_version();
+    bool is_vita_mode() const;
     void printDiagnostic();
-    void do_download();
-    void start_download_package();
+    void do_download(PspInstallMode psp_install_mode = PspInstallMode::Auto);
+    void start_download_package(
+            PspInstallMode psp_install_mode = PspInstallMode::Auto);
     void cancel_download_package();
     void start_download_comppack(bool patch);
     void cancel_download_comppacks(bool patch);

--- a/src/gameview.hpp
+++ b/src/gameview.hpp
@@ -71,12 +71,14 @@ private:
     // ── Focus hierarchy ──────────────────────────────────────────────────────
     // View  → D-pad picks left/right panel; X enters Panel; Circle closes view
     // Panel → ImGui nav inside panel; Circle returns to View
-    // SubItem → ImGui nav inside desc scroll; Circle returns to Panel
-    enum class FocusLevel { View, Panel, SubItem };
-    enum class FocusPanel { Left, Right };
-    FocusLevel _focus_level{FocusLevel::View};
-    FocusPanel _focused_panel{FocusPanel::Right};
-    bool       _request_focus{false}; // set true to seize ImGui focus next frame
+    // SubItem → ImGui nav inside desc/comment scroll; Circle returns to Panel
+    enum class FocusLevel  { View, Panel, SubItem };
+    enum class FocusPanel  { Left, Right };
+    enum class SubItemTarget { Description, Comment };
+    FocusLevel    _focus_level{FocusLevel::View};
+    FocusPanel    _focused_panel{FocusPanel::Right};
+    SubItemTarget _subitem_target{SubItemTarget::Description};
+    bool          _request_focus{false}; // set true to seize ImGui focus next frame
     // ────────────────────────────────────────────────────────────────────────
 
     std::unique_ptr<PatchInfoFetcher>    _patch_info_fetcher;

--- a/src/gameview.hpp
+++ b/src/gameview.hpp
@@ -4,10 +4,12 @@
 #include "comppackdb.hpp"
 #include "config.hpp"
 #include "db.hpp"
+#include "descriptionfetcher.hpp"
 #include "downloader.hpp"
 #include "imagefetcher.hpp"
 #include "install.hpp"
 #include "patchinfofetcher.hpp"
+#include "screenshotfetcher.hpp"
 
 #include <memory>
 
@@ -32,6 +34,12 @@ public:
 
     void render();
     void refresh();
+
+    // Called by pkgi.cpp instead of close() when the cancel button is pressed.
+    // Walks up the focus hierarchy one level per press.
+    // Returns true  → event consumed (don't close).
+    // Returns false → already at top level (caller should call close()).
+    bool handle_cancel();
 
     bool is_closed() const
     {
@@ -60,8 +68,22 @@ private:
 
     bool _closed{false};
 
-    std::unique_ptr<PatchInfoFetcher> _patch_info_fetcher;
-    ImageFetcher _image_fetcher;
+    // ── Focus hierarchy ──────────────────────────────────────────────────────
+    // View  → D-pad picks left/right panel; X enters Panel; Circle closes view
+    // Panel → ImGui nav inside panel; Circle returns to View
+    // SubItem → ImGui nav inside desc scroll; Circle returns to Panel
+    enum class FocusLevel { View, Panel, SubItem };
+    enum class FocusPanel { Left, Right };
+    FocusLevel _focus_level{FocusLevel::View};
+    FocusPanel _focused_panel{FocusPanel::Right};
+    bool       _request_focus{false}; // set true to seize ImGui focus next frame
+    // ────────────────────────────────────────────────────────────────────────
+
+    std::unique_ptr<PatchInfoFetcher>    _patch_info_fetcher;
+    ImageFetcher                         _image_fetcher;
+    std::unique_ptr<DescriptionFetcher>  _description_fetcher; // vita mode only
+    std::unique_ptr<ScreenshotFetcher>   _screenshot_fetcher;  // vita mode only
+    int                                  _selected_screenshot{-1};
 
     // --- Annotation state ---
     AnnotationDatabase* _annotationDb;

--- a/src/imagefetcher.cpp
+++ b/src/imagefetcher.cpp
@@ -3,13 +3,39 @@
 #include "db.hpp"
 #include "file.hpp"
 #include "pkgi.hpp"
-#include "vitahttp.hpp"
+#include "curlhttp.hpp"
+#include "log.hpp"
 
+#ifndef PKGI_SIMULATOR
+#include <vita2d.h>
+#else
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+extern SDL_Renderer* g_sdl_renderer;
+static vita2d_texture* sim_load_jpeg_file(const char* path)
+{
+    SDL_Surface* s = IMG_Load(path);
+    if (!s) return nullptr;
+    SDL_Texture* t = SDL_CreateTextureFromSurface(g_sdl_renderer, s);
+    SDL_FreeSurface(s);
+    return reinterpret_cast<vita2d_texture*>(t);
+}
+#define vita2d_load_JPEG_file(p)     sim_load_jpeg_file(p)
+#define vita2d_wait_rendering_done() ((void)0)
+#define vita2d_free_texture(t)       SDL_DestroyTexture(reinterpret_cast<SDL_Texture*>(t))
+#endif
+
+#include <chrono>
 #include <fmt/format.h>
-#include <mutex>
-#include <optional>
 
-std::string get_image_url(DbItem* item)
+namespace
+{
+bool uses_default_store_source(const Config* config)
+{
+    return !config || config->thumbnail_url.empty();
+}
+
+std::string get_store_image_url(DbItem* item)
 {
     std::string country_abbv = "USA";
     std::string language = "en";
@@ -29,7 +55,7 @@ std::string get_image_url(DbItem* item)
             language = "ko";
             country_abbv = "KR";
         }
-        else if (region.compare("HP2005"))
+        else if (region.compare("HP2005") == 0)
         {
             language = "en";
         }
@@ -47,99 +73,251 @@ std::string get_image_url(DbItem* item)
     }
     return fmt::format(
             "https://store.playstation.com/store/api/chihiro/"
-            "00_09_000/container/{}/{}/19/{}/{}/image?w=248&h=248",
+            "00_09_000/container/{}/{}/19/{}/{}/image?w=248",
             country_abbv,
             language,
             item->content,
             pkgi_time_msec());
 }
 
-ImageFetcher::ImageFetcher(DbItem* item)
-    : _mutex("image_fetcher_mutex")
-    , _path(fmt::format("ux0:pkgj/cover/{}.jpg", item->titleid))
-    , _url(get_image_url(item))
-    , _texture(nullptr)
-    , _thread("image_fetcher", [this] { do_request(); })
+std::string get_image_path(const Config* config, DbItem* item)
 {
-    pkgi_mkdirs("ux0:pkgj/cover");
+    const std::string folder = config && !config->thumbnail_folder.empty()
+            ? config->thumbnail_folder
+            : "ux0:pkgj/cover";
+
+    if ((!config || config->thumbnail_folder.empty()) &&
+        uses_default_store_source(config))
+        return fmt::format("{}/{}.cover.jpg", folder, item->titleid);
+
+    return fmt::format("{}/{}.jpg", folder, item->titleid);
+}
+
+std::string get_image_url(const Config* config, DbItem* item)
+{
+    if (config && !config->thumbnail_url.empty())
+        return fmt::format("{}/{}.jpg", config->thumbnail_url, item->titleid);
+    return get_store_image_url(item);
+}
+
+void ensure_image_folder(const Config* config)
+{
+    const std::string folder = config && !config->thumbnail_folder.empty()
+            ? config->thumbnail_folder
+            : "ux0:pkgj/cover";
+    pkgi_mkdirs(folder.c_str());
+}
+}
+
+ImageFetcher::ImageFetcher(const Config* config, DbItem* item)
+    : _path(get_image_path(config, item))
+    , _url(get_image_url(config, item))
+{
+    ensure_image_folder(config);
+    // Download is NOT started here.  get_status() / get_texture() drive
+    // _try_submit() every frame until the WorkerSlot accepts the task.
 }
 
 ImageFetcher::~ImageFetcher()
 {
-    Http* http;
+    // The worker thread is owned by the global WorkerSlot singleton and
+    // runs to natural completion — we never block here.
+    // We simply drop _result; if the worker is still writing to it the
+    // shared_ptr keeps it alive until the worker releases its own ref.
+    if (_texture)
     {
-        std::lock_guard<Mutex> lock(_mutex);
-        _abort = true;
-        http = _http.get();
+        // Wait for any in-flight GPU frame before freeing the texture.
+        // vita2d queues draw commands asynchronously; the destructor can
+        // run right after render() while the GPU is still reading this
+        // texture.  Without the wait, vita2d_free_texture triggers a GPU
+        // driver crash.  The stall is at most one frame (~16 ms) and only
+        // occurs when the user closes the game view.
+        vita2d_wait_rendering_done();
+        vita2d_free_texture(_texture);
     }
-    if (http)
-        http->abort();
-    _thread.join();
 }
 
+// ── _try_submit ──────────────────────────────────────────────────────────────
+// Called every frame (via get_status) until the WorkerSlot accepts the task.
+void ImageFetcher::_try_submit()
+{
+    // ── Fast path: file already on disc ──────────────────────────────────
+    // No network I/O needed — signal the main thread to load it directly.
+    if (pkgi_file_exists(_path.c_str()))
+    {
+        _pending_jpeg_path = _path;
+        _upload_pending    = true;
+        _submitted         = true;
+        return; // status stays Pending until get_texture() builds the texture
+    }
+
+    if (_url.empty())
+    {
+        _status    = Status::Error;
+        _submitted = true;
+        return;
+    }
+
+    // ── Slow path: submit download to the global WorkerSlot ───────────────
+    // All data captured by VALUE — the lambda must not reference 'this'.
+    // If ImageFetcher is destroyed before the worker finishes, the
+    // shared_ptr keeps ImageFetchResult alive until both sides drop it.
+    auto result = std::make_shared<ImageFetchResult>();
+    const std::string path = _path;
+    const std::string url  = _url;
+
+    if (!WorkerSlot::image_worker().try_submit(
+                _path, // task_id = file path (duplicate detection)
+                [result, path, url]()
+                {
+                    using namespace std::chrono;
+                    const auto t0      = steady_clock::now();
+                    const auto timeout = seconds(8);
+
+                    auto done_error = [&]()
+                    {
+                        result->error = true;
+                        result->ready.store(true, std::memory_order_release);
+                    };
+                    auto done_ok = [&](std::string p)
+                    {
+                        result->error = false;
+                        result->path  = std::move(p);
+                        result->ready.store(true, std::memory_order_release);
+                    };
+
+                    // ── Network ───────────────────────────────────────────
+                    // CurlHttp uses libcurl (TLS 1.2 + ECDHE ciphers).
+                    // VitaHttp (sceHttp) lacks elliptic-curve support and
+                    // fails on modern HTTPS servers — curl is used instead.
+                    CurlHttp http;
+                    try { http.start(url, 0); }
+                    catch (const std::exception& e)
+                    {
+                        LOGFW("[ImageFetcher] HTTP start failed for {}: {}",
+                              path, e.what());
+                        done_error(); return;
+                    }
+
+                    if (http.get_status() == 404) { done_error(); return; }
+
+                    std::vector<uint8_t> data;
+                    data.reserve(32 * 1024);
+                    size_t pos       = 0;
+                    bool   too_large = false;
+
+                    while (true)
+                    {
+                        if (steady_clock::now() - t0 > timeout)
+                            { done_error(); return; }
+
+                        if (pos == data.size())
+                            data.resize(pos + 4096);
+
+                        int64_t n = 0;
+                        try
+                        {
+                            n = http.read(
+                                    data.data() + pos, data.size() - pos);
+                        }
+                        catch (const std::exception& e)
+                        {
+                            LOGFW("[ImageFetcher] HTTP read failed for {}: {}",
+                                  path, e.what());
+                            done_error(); return;
+                        }
+
+                        if (n == 0) break;
+                        pos += static_cast<size_t>(n);
+                        if (pos > ImageFetcher::MAX_SIZE_BYTES)
+                            { too_large = true; break; }
+                    }
+
+                    if (too_large || pos == 0) { done_error(); return; }
+                    data.resize(pos);
+
+                    // ── Save ──────────────────────────────────────────────
+                    // Write to .tmp then rename so the file is never partial.
+                    void* f = nullptr;
+                    try
+                    {
+                        const std::string tmp = path + ".tmp";
+                        f = pkgi_create(tmp);
+                        pkgi_write(f, data.data(), data.size());
+                        pkgi_close(f); f = nullptr;
+                        pkgi_rename(tmp, path);
+                        done_ok(path);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        if (f) pkgi_close(f);
+                        LOGFW("[ImageFetcher] Failed to save {} : {}",
+                              path, e.what());
+                        done_error();
+                    }
+                }))
+    {
+        // Slot is busy — keep _submitted = false and retry next frame.
+        return;
+    }
+
+    _result    = std::move(result);
+    _submitted = true;
+    _status    = Status::Downloading;
+}
+
+// ── get_status ───────────────────────────────────────────────────────────────
+ImageFetcher::Status ImageFetcher::get_status()
+{
+    // Attempt submission every frame until the slot accepts the task.
+    if (!_submitted)
+        _try_submit();
+
+    // Check if the slow-path worker has finished.
+    if (_result && _result->ready.load(std::memory_order_acquire))
+    {
+        if (_result->error || _result->path.empty())
+        {
+            _status = Status::Error;
+        }
+        else
+        {
+            // Signal get_texture() to create the vita2d texture on the
+            // main thread.  Status stays Pending until that happens.
+            _pending_jpeg_path = std::move(_result->path);
+            _upload_pending    = true;
+        }
+        _result.reset(); // release shared ownership
+    }
+
+    return _status;
+}
+
+// ── get_texture ──────────────────────────────────────────────────────────────
 vita2d_texture* ImageFetcher::get_texture()
 {
-    std::lock_guard<Mutex> lock(_mutex);
-    return _texture;
-}
+    // Process any pending worker result first.
+    get_status();
 
-std::optional<std::vector<uint8_t>> download_data(
-        Http* http, const std::string& url)
-{
-    std::vector<uint8_t> data;
-    http->start(url, 0);
-    if (http->get_status() == 404)
-        return std::nullopt;
-    size_t pos = 0;
-    while (true)
-    {
-        if (pos == data.size())
-            data.resize(pos + 4096);
-        const auto read = http->read(data.data() + pos, data.size() - pos);
-        if (read == 0)
-            break;
-        pos += read;
-    }
-    data.resize(pos);
-    return data;
-}
+    if (!_upload_pending)
+        return _texture;
 
-void ImageFetcher::do_request()
-{
-    try
+    // Consume the pending path and create the vita2d texture.
+    // vita2d_load_JPEG_file must run on the main (render) thread.
+    _upload_pending = false;
+    const std::string path = std::move(_pending_jpeg_path);
+
+    vita2d_texture* tex = vita2d_load_JPEG_file(path.c_str());
+    if (!tex)
     {
-        if (pkgi_file_exists(_path.c_str()))
-        {
-            std::lock_guard<Mutex> lock(_mutex);
-            _texture = vita2d_load_JPEG_file(_path.c_str());
-            if (_texture)
-                return;
-        }
-        {
-            std::lock_guard<Mutex> lock(_mutex);
-            if (_abort)
-                return;
-            _http = std::make_unique<VitaHttp>();
-        }
-        const auto image = download_data(_http.get(), _url);
-        {
-            std::lock_guard<Mutex> lock(_mutex);
-            if (image && !image->empty())
-                _texture =
-                        vita2d_load_JPEG_buffer(image->data(), image->size());
-            _http = nullptr;
-        }
-        if (image && !image->empty())
-        {
-            auto image_file = pkgi_create(_path.c_str());
-            pkgi_write(image_file, image->data(), image->size());
-            pkgi_close(image_file);
-        }
+        // Corrupt or unreadable cache file — delete it so the next open
+        // triggers a fresh download instead of looping on the same error.
+        LOGFW("[ImageFetcher] vita2d_load_JPEG_file failed for {}, removing",
+              path);
+        pkgi_rm(path.c_str());
     }
-    catch (const std::exception& e)
-    {
-        LOGF("Failed to fetch patch info: {}", e.what());
-        std::lock_guard<Mutex> lock(_mutex);
-        _http = nullptr;
-    }
+
+    _texture = tex;
+    _status  = tex ? Status::Ready : Status::Error;
+    return tex;
 }

--- a/src/imagefetcher.hpp
+++ b/src/imagefetcher.hpp
@@ -1,28 +1,67 @@
 #pragma once
 
-#include "http.hpp"
-#include "thread.hpp"
+#include "config.hpp"
+#include "workerpool.hpp"
 
+#ifndef PKGI_SIMULATOR
 #include <vita2d.h>
+#else
+// Forward-declare as an opaque pointer in simulator builds.
+// In sdl_backend.cpp the type is reinterpreted as SDL_Texture*.
+struct vita2d_texture;
+#endif
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+// Result written by the worker thread, read by the main thread.
+// The worker sets error/path, then stores ready = true  (release).
+// The main thread loads ready (acquire) before reading error/path.
+// Acquire-release ordering makes path visible without a mutex.
+struct ImageFetchResult
+{
+    std::atomic<bool> ready{false};
+    bool              error{false}; // written before ready = true
+    std::string       path;         // written before ready = true
+};
 
 class ImageFetcher
 {
 public:
-    ImageFetcher(DbItem* item);
+    static constexpr size_t MAX_SIZE_BYTES = 100 * 1024;
+
+    enum class Status
+    {
+        Pending,
+        Downloading,
+        Ready,
+        Error,
+    };
+
+    ImageFetcher(const Config* config, DbItem* item);
     ~ImageFetcher();
 
+    // Must be called from the MAIN thread every frame.
+    // Retries submission to the global WorkerSlot while the slot is busy.
     vita2d_texture* get_texture();
+    Status          get_status();
 
 private:
-    Mutex _mutex;
-
     std::string _path;
     std::string _url;
-    bool _abort{false};
-    std::unique_ptr<Http> _http;
-    vita2d_texture* _texture;
 
-    Thread _thread;
+    bool   _submitted{false};       // true once the slot accepted the task
+    Status _status{Status::Pending};
 
-    void do_request();
+    // Slow-path result from the worker (released once processed).
+    std::shared_ptr<ImageFetchResult> _result;
+
+    vita2d_texture* _texture{nullptr};
+    bool            _upload_pending{false};
+    std::string     _pending_jpeg_path;
+
+    // Try to hand the download task to WorkerSlot::image_worker().
+    // Called every frame via get_status() until the slot accepts it.
+    void _try_submit();
 };

--- a/src/install.cpp
+++ b/src/install.cpp
@@ -88,7 +88,7 @@ void pkgi_install(const char* contentid)
     char path[128];
     snprintf(path, sizeof(path), "ux0:pkgj/%s", contentid);
 
-    LOG("calling scePromoterUtilityPromotePkgWithRif on %s", path);
+    LOG("Installing package from: %s", path);
     const auto res = scePromoterUtilityPromotePkgWithRif(path, 1);
     if (res < 0)
         throw formatEx<std::runtime_error>(
@@ -105,7 +105,7 @@ void pkgi_install_update(const std::string& titleid)
 
     const auto src = fmt::format("ux0:pkgj/{}", titleid);
 
-    LOGF("installing update from {}", src);
+    LOGF("Installing patch from: {}", src);
     const auto res = scePromoterUtilityPromotePkgWithRif(src.c_str(), 1);
     if (res < 0)
         throw formatEx<std::runtime_error>(
@@ -124,7 +124,7 @@ void pkgi_install_comppack(
 
     pkgi_mkdirs(dest.c_str());
 
-    LOGF("installing comp pack from {} to {}", src, dest);
+    LOGF("Installing comppack: src={} dst={}", src, dest);
     pkgi_extract_zip(src, dest);
 
     pkgi_save(
@@ -149,7 +149,7 @@ CompPackVersion pkgi_get_comppack_versions(const std::string& titleid)
         }
         catch (const std::exception& e)
         {
-            LOGF("no base comppack version: {}", e.what());
+            LOGFW("Base comppack version not found: {}", e.what());
             // return empty string if not found
             return std::string{};
         }
@@ -163,7 +163,7 @@ CompPackVersion pkgi_get_comppack_versions(const std::string& titleid)
         }
         catch (const std::exception& e)
         {
-            LOGF("no patch comppack version: {}", e.what());
+            LOGFW("Patch comppack version not found: {}", e.what());
             // return empty string if not found
             return std::string{};
         }
@@ -180,13 +180,13 @@ void pkgi_install_psmgame(const char* contentid)
     const auto src = fmt::format("ux0:pkgj/{}", contentid);
     const auto dest = fmt::format("{}/{}", base, titleid);
 
-    LOGF("moving psm game from {} to {}", src, dest);
+    LOGF("Moving PSM game: {} -> {}", src, dest);
     int res = sceIoRename(src.c_str(), dest.c_str());
     if (res < 0)
         throw formatEx<std::runtime_error>(
                 "failed to rename: {:#08x}", static_cast<uint32_t>(res));
 
-    LOGF("promoting psm game at {}", dest);
+    LOGF("Promoting PSM game at: {}", dest);
     ScePromoterUtilityImportParams promote_args;
     memset(&promote_args, 0, sizeof(promote_args));
 
@@ -206,7 +206,7 @@ void pkgi_install_psmgame(const char* contentid)
 
 void pkgi_install_pspgame(const char* partition, const char* contentid)
 {
-    LOG("Installing a PSP/PSX game");
+    LOG("Installing PSP/PSX game");
     const auto path = fmt::format("{}pkgj/{}", partition, contentid);
     
     const auto eboot_path = fmt::format("{}/EBOOT.PBP", path);
@@ -225,7 +225,7 @@ void pkgi_install_pspgame(const char* partition, const char* contentid)
     // sce_sys folder from pkg not included on psx and psp game
     pkgi_delete_dir(sce_sys_path);
 
-    LOG("installing psx game at %s to %s", path.c_str(), dest.c_str());
+    LOG("Installing PSX game: src=%s dst=%s", path.c_str(), dest.c_str());
     int res = sceIoRename(path.c_str(), dest.c_str());
     
     if (res < 0)
@@ -237,7 +237,7 @@ void pkgi_install_pspgame(const char* partition, const char* contentid)
 
 static void pkgi_move_merge(const std::string& from, const std::string& to)
 {
-    LOGF("Merging {} and {}", from, to);
+    LOGF("Merging PSX disc: {} into {}", from, to);
     const auto fromType = pkgi_get_inode_type(from);
     const auto toType = pkgi_get_inode_type(to);
     if (toType == InodeType::NotExist ||
@@ -279,7 +279,7 @@ void pkgi_install_pspgame_as_iso(const char* partition, const char* contentid)
 
     pkgi_mkdirs(fmt::format("{}pspemu/ISO", partition).c_str());
 
-    LOG("installing psp game at %s to %s", path.c_str(), dest.c_str());
+    LOG("Installing PSP game as ISO: src=%s dst=%s", path.c_str(), dest.c_str());
     pkgi_rename(eboot.c_str(), isodest.c_str());
 
     const auto content_exists = pkgi_file_exists(content.c_str());
@@ -299,14 +299,14 @@ void pkgi_install_pspgame_as_iso(const char* partition, const char* contentid)
 
 void pkgi_install_pspdlc(const char* partition, const char* contentid)
 {
-    LOG("Installing a PSP DLC");
+    LOG("Installing PSP DLC");
     const auto path = fmt::format("{}pkgj/{}", partition, contentid);
     const auto dest =
             fmt::format("{}pspemu/PSP/GAME/{:.9}", partition, contentid + 7);
 
     pkgi_mkdirs(fmt::format("{}pspemu/PSP/GAME", partition).c_str());
 
-    LOG("installing psp dlc at %s to %s", path.c_str(), dest.c_str());
+    LOG("Installing PSP DLC: src=%s dst=%s", path.c_str(), dest.c_str());
     pkgi_move_merge(path, dest);
     pkgi_delete_dir(path);
 }

--- a/src/log.hpp
+++ b/src/log.hpp
@@ -1,29 +1,86 @@
 #pragma once
 
+#include "logbuffer.hpp"
 #include <fmt/format.h>
 #include <stdexcept>
+#include <string>
 
-#ifdef PKGI_ENABLE_LOGGING
-#define LOG(msg, ...)                 \
-    do                                \
-    {                                 \
-        pkgi_log(msg, ##__VA_ARGS__); \
+// Compile-time: strip directory and extension from __FILE__, e.g. "downloader"
+namespace pkgi_log_detail
+{
+constexpr const char* basename(const char* path)
+{
+    const char* last = path;
+    for (const char* p = path; *p; ++p)
+        if (*p == '/' || *p == '\\')
+            last = p + 1;
+    return last;
+}
+
+// Returns length of stem (chars before the last '.')
+constexpr int stem_len(const char* name)
+{
+    int len = 0, last_dot = -1;
+    for (int i = 0; name[i]; ++i)
+    {
+        if (name[i] == '.')
+            last_dot = i;
+        ++len;
+    }
+    return last_dot > 0 ? last_dot : len;
+}
+} // namespace pkgi_log_detail
+
+// We can't use a runtime-truncated string in a constexpr context easily,
+// so we format the stem length at runtime — still zero .cpp allocation.
+#define PKGI_LOG_MODULE                                           \
+    ([]() -> std::string {                                        \
+        const char* b = pkgi_log_detail::basename(__FILE__);      \
+        return std::string(b, pkgi_log_detail::stem_len(b));      \
+    }())
+
+#define LOG(msg, ...)                                                                    \
+    do                                                                                   \
+    {                                                                                    \
+        pkgi_log(LogLevel::Info, "[%s] " msg, PKGI_LOG_MODULE.c_str(), ##__VA_ARGS__);   \
     } while (0)
-#define LOGF(msg, ...)                                     \
-    do                                                     \
-    {                                                      \
-        pkgi_log(fmt::format(msg, ##__VA_ARGS__).c_str()); \
+
+#define LOG_WARN(msg, ...)                                                               \
+    do                                                                                   \
+    {                                                                                    \
+        pkgi_log(LogLevel::Warn, "[%s] " msg, PKGI_LOG_MODULE.c_str(), ##__VA_ARGS__);   \
     } while (0)
-#else
-#define LOG(...) \
-    do           \
-    {            \
+
+#define LOG_ERR(msg, ...)                                                                \
+    do                                                                                   \
+    {                                                                                    \
+        pkgi_log(LogLevel::Error, "[%s] " msg, PKGI_LOG_MODULE.c_str(), ##__VA_ARGS__);  \
     } while (0)
-#define LOGF(...) \
-    do            \
-    {             \
+
+// fmt-based variants
+#define LOGF(msg, ...)                                                                   \
+    do                                                                                   \
+    {                                                                                    \
+        pkgi_log(LogLevel::Info, "[%s] %s",                                              \
+                PKGI_LOG_MODULE.c_str(),                                                 \
+                fmt::format(msg, ##__VA_ARGS__).c_str());                                \
     } while (0)
-#endif
+
+#define LOGFW(msg, ...)                                                                  \
+    do                                                                                   \
+    {                                                                                    \
+        pkgi_log(LogLevel::Warn, "[%s] %s",                                              \
+                PKGI_LOG_MODULE.c_str(),                                                 \
+                fmt::format(msg, ##__VA_ARGS__).c_str());                                \
+    } while (0)
+
+#define LOGFE(msg, ...)                                                                  \
+    do                                                                                   \
+    {                                                                                    \
+        pkgi_log(LogLevel::Error, "[%s] %s",                                             \
+                PKGI_LOG_MODULE.c_str(),                                                 \
+                fmt::format(msg, ##__VA_ARGS__).c_str());                                \
+    } while (0)
 
 template <typename E = std::runtime_error, typename... Args>
 [[nodiscard]] E formatEx(Args&&... args)
@@ -31,4 +88,4 @@ template <typename E = std::runtime_error, typename... Args>
     return E(fmt::format(std::forward<Args>(args)...));
 }
 
-void pkgi_log(const char* msg, ...);
+void pkgi_log(LogLevel level, const char* msg, ...);

--- a/src/logbuffer.cpp
+++ b/src/logbuffer.cpp
@@ -1,0 +1,47 @@
+#include "logbuffer.hpp"
+
+#include <ctime>
+#include <deque>
+#include <mutex>
+
+namespace
+{
+std::mutex g_log_mutex;
+std::deque<LogEntry> g_log_lines;
+
+constexpr std::size_t MaxLogLines = 512;
+}
+
+void pkgi_log_buffer_append(LogLevel level, const char* line)
+{
+    if (!line)
+        return;
+
+    std::string text(line);
+    while (!text.empty() &&
+           (text.back() == '\n' || text.back() == '\r'))
+    {
+        text.pop_back();
+    }
+
+    // Prepend HH:MM:SS [LEVL] timestamp from system clock
+    char ts[10];
+    std::time_t now = std::time(nullptr);
+    std::tm* tm_now = std::localtime(&now);
+    std::strftime(ts, sizeof(ts), "%H:%M:%S", tm_now);
+    const char* lvl = level == LogLevel::Error ? "ERR "
+                    : level == LogLevel::Warn  ? "WARN"
+                    :                            "INFO";
+    text = std::string(ts) + " [" + lvl + "] " + text;
+
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    g_log_lines.push_back({level, std::move(text)});
+    while (g_log_lines.size() > MaxLogLines)
+        g_log_lines.pop_front();
+}
+
+std::vector<LogEntry> pkgi_log_buffer_snapshot()
+{
+    std::lock_guard<std::mutex> lock(g_log_mutex);
+    return {g_log_lines.begin(), g_log_lines.end()};
+}

--- a/src/logbuffer.hpp
+++ b/src/logbuffer.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+enum class LogLevel
+{
+    Info,
+    Warn,
+    Error,
+};
+
+struct LogEntry
+{
+    LogLevel    level;
+    std::string text; // already includes timestamp + level tag
+};
+
+void                    pkgi_log_buffer_append(LogLevel level, const char* line);
+std::vector<LogEntry>   pkgi_log_buffer_snapshot();

--- a/src/logviewer.cpp
+++ b/src/logviewer.cpp
@@ -1,0 +1,126 @@
+#include "logviewer.hpp"
+
+#include "imgui.hpp"
+#include "logbuffer.hpp"
+
+extern "C"
+{
+#include "style.h"
+}
+
+namespace
+{
+constexpr float ViewerW = VITA_WIDTH * 0.9f;
+constexpr float ViewerH = VITA_HEIGHT * 0.85f;
+}
+
+void LogViewer::render(const pkgi_input& input)
+{
+    const auto lines = pkgi_log_buffer_snapshot();
+    const int  n     = static_cast<int>(lines.size());
+
+    // ── Navigation ────────────────────────────────────────────────────────────
+    // Use input.active — same field as pkgi_do_main — so repeat rate and
+    // initial-press delay are identical to the main game list.
+    bool nav_step = false;
+
+    if ((input.active & PKGI_BUTTON_UP) && n > 0)
+    {
+        _selected = std::max(0, _selected - 1);
+        nav_step  = true;
+    }
+    else if ((input.active & PKGI_BUTTON_DOWN) && n > 0)
+    {
+        _selected = std::min(n - 1, _selected + 1);
+        nav_step  = true;
+    }
+
+    // Clamp in case log buffer shrank
+    if (n == 0)
+        _selected = 0;
+    else
+        _selected = std::max(0, std::min(_selected, n - 1));
+
+    // Inverted order: index 0 is newest entry (top of viewport).
+    // _selected is still in [0, n-1], where 0 means newest.
+    
+    // ── Window ────────────────────────────────────────────────────────────────
+    ImGui::SetNextWindowPos(
+            ImVec2((VITA_WIDTH  - ViewerW) / 2.f,
+                   (VITA_HEIGHT - ViewerH) / 2.f));
+    ImGui::SetNextWindowSize(ImVec2(ViewerW, ViewerH), 0);
+
+    ImGui::Begin(
+            "Log Viewer###logviewer",
+            nullptr,
+            ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+                    ImGuiWindowFlags_NoCollapse |
+                    ImGuiWindowFlags_NoSavedSettings |
+                    ImGuiWindowFlags_NoScrollbar |
+                    ImGuiWindowFlags_NoScrollWithMouse);
+
+    ImGui::Text("Lines: %d", n);
+    ImGui::Separator();
+
+    const float footer_h =
+            ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y;
+
+    // NoNav: we handle navigation ourselves
+    ImGui::BeginChild(
+            "##logrows",
+            ImVec2(0.f, -footer_h),
+            false,
+            ImGuiWindowFlags_NoNav);
+
+    if (n == 0)
+    {
+        ImGui::TextDisabled("(no log messages yet)");
+    }
+    else
+    {
+        for (int i = 0; i < n; ++i)
+        {
+            ImGui::PushID(i);
+
+            const int        idx      = n - 1 - i; // newest first
+            const bool       selected = (i == _selected);
+            const LogEntry&  entry    = lines[idx];
+            const char*      text     = entry.text.empty() ? " " : entry.text.c_str();
+
+            // Color by level
+            ImVec4 col;
+            switch (entry.level)
+            {
+            case LogLevel::Error:
+                col = ImVec4(1.00f, 0.35f, 0.35f, 1.f);
+                break;
+            case LogLevel::Warn:
+                col = ImVec4(1.00f, 0.85f, 0.10f, 1.f);
+                break;
+            default:
+                col = ImVec4(1.00f, 1.00f, 1.00f, 1.f);
+                break;
+            }
+
+            ImGui::PushStyleColor(ImGuiCol_Text, col);
+            ImGui::Selectable(text, selected, ImGuiSelectableFlags_Disabled);
+            ImGui::PopStyleColor();
+
+            // Scroll the selected row into view whenever navigation occurred
+            if (selected && nav_step)
+                ImGui::SetScrollHereY(0.5f);
+
+            ImGui::PopID();
+        }
+    }
+
+    ImGui::EndChild();
+
+    ImGui::Separator();
+    ImGui::TextDisabled(
+            "[Up/Down] navigate   "
+            "(hold 1s = fast scroll)   "
+            "[Circle] close");
+
+    ImGui::End();
+}

--- a/src/logviewer.hpp
+++ b/src/logviewer.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "pkgi.hpp"
+
+class LogViewer
+{
+public:
+    // input: raw snapshot BEFORE pkgi.cpp zeros it.
+    void render(const pkgi_input& input);
+
+    bool is_closed() const { return _closed; }
+    void close() { _closed = true; }
+
+private:
+    int  _selected{0};
+    bool _closed{false};
+};

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -28,6 +28,7 @@ typedef enum
     MenuRefresh,
     MenuConfigEdit,
     MenuLogView,
+    MenuBack,
     MenuShow,
 } MenuType;
 
@@ -60,14 +61,7 @@ static const MenuEntry menu_entries[] = {
         {MenuConfigEdit, "Edit config.txt", 0},
         {MenuLogView, "Log viewer", 0},
 
-        {MenuShow, "Show games", 1},
-        {MenuShow, "Show DLCs", 2},
-        {MenuShow, "Show demos", 64},
-        {MenuShow, "Show themes", 32},
-        {MenuShow, "Show PS1 games", 4},
-        {MenuShow, "Show PSP games", 8},
-        {MenuShow, "Show PSP DLCs", 128},
-        {MenuShow, "Show PSM games", 16},
+        {MenuBack, "Back to categories", 0},
 };
 
 int pkgi_menu_is_open(void)
@@ -209,36 +203,9 @@ int pkgi_do_menu(pkgi_input* input)
             menu_delta = -1;
             return 1;
         }
-        else if (type == MenuShow)
+        else if (type == MenuBack)
         {
-            switch (menu_entries[menu_selected].value)
-            {
-            case 1:
-                menu_result = MenuResultShowGames;
-                break;
-            case 2:
-                menu_result = MenuResultShowDlcs;
-                break;
-            case 4:
-                menu_result = MenuResultShowPsxGames;
-                break;
-            case 8:
-                menu_result = MenuResultShowPspGames;
-                break;
-            case 16:
-                menu_result = MenuResultShowPsmGames;
-                break;
-            case 32:
-                menu_result = MenuResultShowThemes;
-                break;
-            case 64:
-                menu_result = MenuResultShowDemos;
-                break;
-            case 128:
-                menu_result = MenuResultShowPspDlcs;
-                break;
-            }
-
+            menu_result = MenuResultBackToBrowse;
             menu_delta = -1;
             return 1;
         }
@@ -301,7 +268,7 @@ int pkgi_do_menu(pkgi_input* input)
         char text[64];
         if (type == MenuSearch || type == MenuSearchClear || type == MenuText ||
             type == MenuRefresh || type == MenuConfigEdit || type == MenuLogView ||
-            type == MenuShow)
+            type == MenuBack || type == MenuShow)
         {
             pkgi_strncpy(text, sizeof(text), entry->text);
         }

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -26,6 +26,8 @@ typedef enum
     MenuSort,
     MenuFilter,
     MenuRefresh,
+    MenuConfigEdit,
+    MenuLogView,
     MenuShow,
 } MenuType;
 
@@ -55,6 +57,8 @@ static const MenuEntry menu_entries[] = {
         {MenuFilter, "Installed games only", DbFilterInstalled},
 
         {MenuRefresh, "Refresh", 0},
+        {MenuConfigEdit, "Edit config.txt", 0},
+        {MenuLogView, "Log viewer", 0},
 
         {MenuShow, "Show games", 1},
         {MenuShow, "Show DLCs", 2},
@@ -193,6 +197,18 @@ int pkgi_do_menu(pkgi_input* input)
             menu_delta = -1;
             return 1;
         }
+        else if (type == MenuConfigEdit)
+        {
+            menu_result = MenuResultOpenConfigEditor;
+            menu_delta = -1;
+            return 1;
+        }
+        else if (type == MenuLogView)
+        {
+            menu_result = MenuResultOpenLogViewer;
+            menu_delta = -1;
+            return 1;
+        }
         else if (type == MenuShow)
         {
             switch (menu_entries[menu_selected].value)
@@ -284,7 +300,8 @@ int pkgi_do_menu(pkgi_input* input)
 
         char text[64];
         if (type == MenuSearch || type == MenuSearchClear || type == MenuText ||
-            type == MenuRefresh || type == MenuShow)
+            type == MenuRefresh || type == MenuConfigEdit || type == MenuLogView ||
+            type == MenuShow)
         {
             pkgi_strncpy(text, sizeof(text), entry->text);
         }

--- a/src/menu.hpp
+++ b/src/menu.hpp
@@ -19,6 +19,8 @@ typedef enum
     MenuResultShowPspGames,
     MenuResultShowPspDlcs,
     MenuResultShowPsmGames,
+    MenuResultOpenConfigEditor,
+    MenuResultOpenLogViewer,
 } MenuResult;
 
 typedef struct Config Config;

--- a/src/menu.hpp
+++ b/src/menu.hpp
@@ -11,6 +11,7 @@ typedef enum
     MenuResultAccept,
     MenuResultCancel,
     MenuResultRefresh,
+    MenuResultBackToBrowse,
     MenuResultShowGames,
     MenuResultShowDlcs,
     MenuResultShowDemos,

--- a/src/patchinfofetcher.cpp
+++ b/src/patchinfofetcher.cpp
@@ -60,7 +60,7 @@ void PatchInfoFetcher::do_request()
     }
     catch (const std::exception& e)
     {
-        LOGF("Failed to fetch patch info: {}", e.what());
+        LOGFW("Failed to fetch patch info: {}", e.what());
         std::lock_guard<Mutex> lock(_mutex);
         _status = Status::Error;
         _http = nullptr;

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -40,6 +40,7 @@ extern SDL_Texture* sim_create_font_texture(const uint32_t* px, int w, int h);
 
 #include <memory>
 #include <set>
+#include <cctype>
 
 #ifndef PKGI_SIMULATOR
 #include <psp2common/npdrm.h>
@@ -216,6 +217,160 @@ std::string const& pkgi_get_url_from_mode(Mode mode)
     }
     throw std::runtime_error(
             fmt::format("unknown mode: {}", static_cast<int>(mode)));
+}
+
+static const int PKGI_GROUP_COUNT = 29;
+
+static bool pkgi_utf8_next_codepoint(
+        const std::string& text,
+        size_t& pos,
+        uint32_t& codepoint)
+{
+    if (pos >= text.size())
+        return false;
+
+    const unsigned char c = static_cast<unsigned char>(text[pos]);
+    if (c < 0x80)
+    {
+        codepoint = c;
+        pos += 1;
+        return true;
+    }
+    if ((c & 0xE0) == 0xC0 && pos + 1 < text.size())
+    {
+        const unsigned char c1 = static_cast<unsigned char>(text[pos + 1]);
+        codepoint = ((c & 0x1F) << 6) | (c1 & 0x3F);
+        pos += 2;
+        return true;
+    }
+    if ((c & 0xF0) == 0xE0 && pos + 2 < text.size())
+    {
+        const unsigned char c1 = static_cast<unsigned char>(text[pos + 1]);
+        const unsigned char c2 = static_cast<unsigned char>(text[pos + 2]);
+        codepoint = ((c & 0x0F) << 12) | ((c1 & 0x3F) << 6) |
+                    (c2 & 0x3F);
+        pos += 3;
+        return true;
+    }
+    if ((c & 0xF8) == 0xF0 && pos + 3 < text.size())
+    {
+        const unsigned char c1 = static_cast<unsigned char>(text[pos + 1]);
+        const unsigned char c2 = static_cast<unsigned char>(text[pos + 2]);
+        const unsigned char c3 = static_cast<unsigned char>(text[pos + 3]);
+        codepoint = ((c & 0x07) << 18) | ((c1 & 0x3F) << 12) |
+                    ((c2 & 0x3F) << 6) | (c3 & 0x3F);
+        pos += 4;
+        return true;
+    }
+
+    // Invalid UTF-8 sequence, skip one byte.
+    pos += 1;
+    return false;
+}
+
+static bool pkgi_is_other_script(uint32_t c)
+{
+    // CJK and East Asian blocks.
+    if ((0x3040 <= c && c <= 0x30FF) ||  // Hiragana/Katakana
+        (0x31F0 <= c && c <= 0x31FF) ||  // Katakana Phonetic Extensions
+        (0x3400 <= c && c <= 0x4DBF) ||  // CJK Extension A
+        (0x4E00 <= c && c <= 0x9FFF) ||  // CJK Unified Ideographs
+        (0xF900 <= c && c <= 0xFAFF) ||  // CJK Compatibility Ideographs
+        (0xAC00 <= c && c <= 0xD7AF) ||  // Hangul Syllables
+        (0x1100 <= c && c <= 0x11FF) ||  // Hangul Jamo
+        (0x3130 <= c && c <= 0x318F) ||  // Hangul Compatibility Jamo
+        (0x20000 <= c && c <= 0x2FA1F) || // Additional CJK
+        (0x3000 <= c && c <= 0x303F))    // CJK Symbols and Punctuation
+        return true;
+    return false;
+}
+
+static int pkgi_name_group(const std::string& name)
+{
+    size_t i = 0;
+    while (i < name.size() && std::isspace(static_cast<unsigned char>(name[i])))
+        ++i;
+
+    while (i < name.size())
+    {
+        uint32_t cp;
+        if (!pkgi_utf8_next_codepoint(name, i, cp))
+            continue;
+
+        if (cp < 0x80)
+        {
+            if (cp >= '0' && cp <= '9')
+                return 0;
+            if (cp == '@')
+                return 1;
+            if (cp >= 'A' && cp <= 'Z')
+                return static_cast<int>(cp - 'A') + 2;
+            if (cp >= 'a' && cp <= 'z')
+                return static_cast<int>(cp - 'a') + 2;
+            if (std::ispunct(static_cast<unsigned char>(cp)))
+                return 1;
+            if (std::isspace(static_cast<unsigned char>(cp)))
+                continue;
+            return 28;
+        }
+
+        if (pkgi_is_other_script(cp))
+            return 28;
+
+        // Non-ASCII non-CJK characters are treated as Other.
+        return 28;
+    }
+
+    return 28;
+}
+
+static const char* pkgi_group_label(int group)
+{
+    if (group == 0)
+        return "0-9";
+    if (group == 1)
+        return "@";
+    if (group >= 2 && group <= 27)
+    {
+        static char text[2] = "A";
+        text[0] = static_cast<char>('A' + group - 2);
+        return text;
+    }
+    return "Other";
+}
+
+static int pkgi_next_group(int current, const bool present[PKGI_GROUP_COUNT], bool forward)
+{
+    if (current < 0 || current >= PKGI_GROUP_COUNT)
+        current = 0;
+
+    for (int step = 1; step < PKGI_GROUP_COUNT; ++step)
+    {
+        int idx = forward
+                ? (current + step) % PKGI_GROUP_COUNT
+                : (current + PKGI_GROUP_COUNT - step) % PKGI_GROUP_COUNT;
+        if (present[idx])
+            return idx;
+    }
+    return current;
+}
+
+static uint32_t pkgi_first_item_with_group(int group)
+{
+    const uint32_t db_count = db ? db->count() : 0;
+    for (uint32_t i = 0; i < db_count; ++i)
+        if (pkgi_name_group(db->get(i)->name) == group)
+            return i;
+    return 0;
+}
+
+static std::string pkgi_group_overlay_text;
+static uint32_t pkgi_group_overlay_until = 0;
+
+static void pkgi_set_group_overlay(int group)
+{
+    pkgi_group_overlay_text = pkgi_group_label(group);
+    pkgi_group_overlay_until = pkgi_time_msec() + 2000;
 }
 
 void pkgi_refresh_thread(void)
@@ -477,6 +632,35 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
             }
         }
 
+        if (input->pressed & PKGI_BUTTON_LT)
+        {
+            if (db_count != 0)
+            {
+                if (selected_item >= db_count)
+                    selected_item = 0;
+
+                bool present[PKGI_GROUP_COUNT] = {};
+                for (uint32_t i = 0; i < db_count; ++i)
+                    present[pkgi_name_group(db->get(i)->name)] = true;
+
+                int current_group = pkgi_name_group(db->get(selected_item)->name);
+                int group = pkgi_next_group(current_group, present, false);
+                if (group != current_group || !present[current_group])
+                {
+                    selected_item = pkgi_first_item_with_group(group);
+                    uint32_t max_items =
+                            avail_height / (font_height + PKGI_MAIN_ROW_PADDING) - 1;
+                    if (selected_item < first_item)
+                        first_item = selected_item;
+                    else if (selected_item > first_item + max_items)
+                        first_item = selected_item > max_items
+                                         ? selected_item - max_items
+                                         : 0;
+                    pkgi_set_group_overlay(group);
+                }
+            }
+        }
+
         if (input->active & PKGI_BUTTON_RIGHT)
         {
             uint32_t max_items =
@@ -488,6 +672,35 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
                 if (selected_item >= db_count)
                 {
                     selected_item = db_count - 1;
+                }
+            }
+        }
+
+        if (input->pressed & PKGI_BUTTON_RT)
+        {
+            if (db_count != 0)
+            {
+                if (selected_item >= db_count)
+                    selected_item = 0;
+
+                bool present[PKGI_GROUP_COUNT] = {};
+                for (uint32_t i = 0; i < db_count; ++i)
+                    present[pkgi_name_group(db->get(i)->name)] = true;
+
+                int current_group = pkgi_name_group(db->get(selected_item)->name);
+                int group = pkgi_next_group(current_group, present, true);
+                if (group != current_group || !present[current_group])
+                {
+                    selected_item = pkgi_first_item_with_group(group);
+                    uint32_t max_items =
+                            avail_height / (font_height + PKGI_MAIN_ROW_PADDING) - 1;
+                    if (selected_item < first_item)
+                        first_item = selected_item;
+                    else if (selected_item > first_item + max_items)
+                        first_item = selected_item > max_items
+                                         ? selected_item - max_items
+                                         : 0;
+                    pkgi_set_group_overlay(group);
                 }
             }
         }
@@ -706,6 +919,22 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
                     height,
                     PKGI_COLOR_SCROLL_BAR);
         }
+    }
+
+    if (!pkgi_group_overlay_text.empty() &&
+            pkgi_time_msec() < pkgi_group_overlay_until)
+    {
+        const float scale = 4.0f;
+        int w = static_cast<int>(pkgi_text_width(pkgi_group_overlay_text.c_str()) * scale);
+        int h = static_cast<int>(pkgi_text_height("M") * scale);
+        int text_top = (VITA_HEIGHT - h) / 2;
+        int x = (VITA_WIDTH - w) / 2;
+        int y = text_top - 20;
+        if (y < 0)
+            y = 0;
+        pkgi_draw_rect(x - 12, text_top - 12, w + 24, h + 24, PKGI_COLOR_MENU_BACKGROUND);
+        pkgi_draw_text_scale(
+                x, y, PKGI_COLOR_TEXT_HEAD, pkgi_group_overlay_text.c_str(), scale);
     }
 
     if (input && (input->pressed & pkgi_ok_button()))

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -4,9 +4,11 @@ extern "C"
 {
 #include "style.h"
 }
+#include "annotationdb.hpp"
 #include "bgdl.hpp"
 #include "comppackdb.hpp"
 #include "config.hpp"
+#include "configeditor.hpp"
 #include "db.hpp"
 #include "dialog.hpp"
 #include "download.hpp"
@@ -14,6 +16,7 @@ extern "C"
 #include "gameview.hpp"
 #include "imgui.hpp"
 #include "install.hpp"
+#include "logviewer.hpp"
 #include "menu.hpp"
 #include "update.hpp"
 #include "utils.hpp"
@@ -22,15 +25,24 @@ extern "C"
 #include "psm.hpp"
 #include "file.hpp"
 
+#ifndef PKGI_SIMULATOR
 #include <vita2d.h>
+#endif
+
+#ifdef PKGI_SIMULATOR
+#include <SDL2/SDL.h>
+extern SDL_Texture* sim_create_font_texture(const uint32_t* px, int w, int h);
+#endif
 
 #include <fmt/format.h>
 
 #include <memory>
 #include <set>
 
+#ifndef PKGI_SIMULATOR
 #include <psp2common/npdrm.h>
 #include <psp2/io/stat.h>
+#endif
 
 #include <cstddef>
 #include <cstring>
@@ -40,6 +52,9 @@ extern "C"
 
 namespace
 {
+// forward declaration — defined later in this anonymous namespace
+void pkgi_apply_annotations();
+
 typedef enum
 {
     StateError,
@@ -78,10 +93,18 @@ std::set<std::string> installed_games;
 std::set<std::string> installed_themes;
 
 std::unique_ptr<GameView> gameview;
+std::unique_ptr<ConfigEditor> config_editor;
+std::unique_ptr<LogViewer> log_viewer;
+std::unique_ptr<AnnotationDatabase> annotation_db;
 bool need_refresh = true;
 bool runtime_install_queued = false;
 std::string content_to_refresh;
 void pkgi_reload();
+
+bool pkgi_overlay_is_open()
+{
+    return gameview || config_editor || log_viewer;
+}
 
 const char* pkgi_get_ok_str(void)
 {
@@ -193,7 +216,7 @@ std::string const& pkgi_get_url_from_mode(Mode mode)
 
 void pkgi_refresh_thread(void)
 {
-    LOG("starting update");
+    LOG("Checking for app updates");
     try
     {
         auto mode_count = ModeCount + (config.comppack_url.empty() ? 0 : 2);
@@ -246,6 +269,7 @@ void pkgi_refresh_thread(void)
         first_item = 0;
         selected_item = 0;
         configure_db(db.get(), search_active ? search_text : NULL, &config);
+        pkgi_apply_annotations();
     }
     catch (const std::exception& e)
     {
@@ -332,12 +356,12 @@ void pkgi_friendly_size(char* text, uint32_t textlen, int64_t size)
     }
     else if (size < 1000LL * 1000)
     {
-        pkgi_snprintf(text, textlen, "%.2f " PKGI_UTF8_KB, size / 1024.f);
+        pkgi_snprintf(text, textlen, "%.2f " PKGI_UTF8_KB, size / 1000.f);
     }
     else if (size < 1000LL * 1000 * 1000)
     {
         pkgi_snprintf(
-                text, textlen, "%.2f " PKGI_UTF8_MB, size / 1024.f / 1024.f);
+                text, textlen, "%.2f " PKGI_UTF8_MB, size / 1000.f / 1000.f);
     }
     else
     {
@@ -345,7 +369,7 @@ void pkgi_friendly_size(char* text, uint32_t textlen, int64_t size)
                 text,
                 textlen,
                 "%.2f " PKGI_UTF8_GB,
-                size / 1024.f / 1024.f / 1024.f);
+                size / 1000.f / 1000.f / 1000.f);
     }
 }
 
@@ -361,6 +385,15 @@ void pkgi_refresh_list()
 {
     state = StateRefreshing;
     pkgi_start_thread("refresh_thread", &pkgi_refresh_thread);
+}
+
+void pkgi_mark_all_items_unknown()
+{
+    if (!db)
+        return;
+
+    for (uint32_t i = 0; i < db->count(); ++i)
+        db->get(i)->presence = PresenceUnknown;
 }
 
 void pkgi_do_main(Downloader& downloader, pkgi_input* input)
@@ -605,7 +638,17 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
                         PKGI_MAIN_COLUMN_PADDING - sizew - col_name,
                 line_height);
         item->selected = std::find(selected_items.begin(), selected_items.end(), item) != selected_items.end();
-        pkgi_draw_text(col_name, y, item->selected ? PKGI_COLOR_TEXT_SELECTED : PKGI_COLOR_TEXT , item->name.c_str());
+        {
+            std::string display_name;
+            if (item->user_flag != UserFlag::None)
+                display_name = fmt::format("{} {}",
+                        user_flag_symbol(item->user_flag), item->name);
+            else
+                display_name = item->name;
+            pkgi_draw_text(col_name, y,
+                    item->selected ? PKGI_COLOR_TEXT_SELECTED : PKGI_COLOR_TEXT,
+                    display_name.c_str());
+        }
         pkgi_clip_remove();
 
         y += font_height + PKGI_MAIN_ROW_PADDING;
@@ -669,13 +712,17 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
             return;
         DbItem* item = db->get(selected_item);
 
-        if (mode == ModeGames)
+        if (mode == ModeGames || mode == ModePspGames)
             gameview = std::make_unique<GameView>(
+                mode,
                     &config,
                     &downloader,
                     item,
-                    comppack_db_games->get(item->titleid),
-                    comppack_db_updates->get(item->titleid));
+                mode == ModeGames ? comppack_db_games->get(item->titleid)
+                          : std::optional<CompPackDatabase::Item>{},
+                mode == ModeGames ? comppack_db_updates->get(item->titleid)
+                          : std::optional<CompPackDatabase::Item>{},
+                    annotation_db.get());
         else if (mode == ModeThemes || mode == ModeDemos)
         {
             pkgi_start_download(downloader, *item);
@@ -694,7 +741,7 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
             }
             else
             {
-                for(int i = 0; i < selected_items.size(); i++)
+                for(size_t i = 0; i < selected_items.size(); i++)
                 {
                     if (downloader.is_in_queue(mode_to_type(mode), selected_items[i]->content))
                     {
@@ -721,7 +768,33 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
     }
     else if (input && (input->pressed & PKGI_BUTTON_S))
     {
-        if (mode == ModeDlcs) 
+        /*
+        * Annotation Flag Cycling Logic
+        * ----------------------------
+        * This block handles user flag annotation for games.
+        * - When the S button is pressed in ModeGames, the currently selected game's user_flag is cycled forward (wraps around).
+        * - The new flag is saved immediately to the annotation database (AnnotationDatabase).
+        * - Flags are defined in src/annotationdb.hpp as UserFlag enum.
+        * - The annotation system allows users to mark games with custom statuses (Favorite, Good, Bad, Completed, etc.).
+        * - See also: src/annotationdb.cpp, src/db.hpp, src/gameview.cpp for UI integration.
+        *
+        * Related context: .github/copilot-instructions.md (Annotation Feature section)
+        */
+        if (mode == ModeGames || mode == ModePspGames)
+        {
+            input->pressed &= ~PKGI_BUTTON_S;
+            DbItem* item = db->get(selected_item);
+            if (item && annotation_db)
+            {
+                // Cycle flag forward (wraps around)
+                const int next = (static_cast<int>(item->user_flag) + 1) % UserFlagCount;
+                item->user_flag = static_cast<UserFlag>(next);
+                UserAnnotation ann = annotation_db->get(item->titleid);
+                ann.flag = item->user_flag;
+                annotation_db->set(item->titleid, ann);
+            }
+        }
+        else if (mode == ModeDlcs) 
         {
             input->pressed &= ~PKGI_BUTTON_S;
             DbItem* item = db->get(selected_item);
@@ -966,7 +1039,7 @@ void pkgi_do_tail(Downloader& downloader)
     int right = rightw + PKGI_MAIN_TEXT_PADDING;
 
     std::string bottom_text;
-    if (gameview || pkgi_dialog_is_open())
+    if (pkgi_overlay_is_open() || pkgi_dialog_is_open())
     {
         bottom_text = fmt::format(
                 "{} select {} close", pkgi_get_ok_str(), pkgi_get_cancel_str());
@@ -980,8 +1053,11 @@ void pkgi_do_tail(Downloader& downloader)
     }
     else
     {
-        if (mode == ModeGames)
+        if (mode == ModeGames || mode == ModePspGames)
+        {
             bottom_text += fmt::format("{} details ", pkgi_get_ok_str());
+            bottom_text += PKGI_UTF8_S " flag ";
+        }
         else
         {
             DbItem* item = db->get(selected_item);
@@ -1041,15 +1117,30 @@ void reposition(void)
     }
 }
 
+void pkgi_apply_annotations()
+{
+    if (!annotation_db)
+        return;
+    for (uint32_t i = 0; i < db->count(); ++i)
+    {
+        auto* item = db->get(i);
+        if (!item) continue;
+        const auto ann = annotation_db->get(item->titleid);
+        item->user_flag    = ann.flag;
+        item->user_comment = ann.comment;
+    }
+}
+
 void pkgi_reload()
 {
     try
     {
         configure_db(db.get(), search_active ? search_text : NULL, &config);
+        pkgi_apply_annotations();
     }
     catch (const std::exception& e)
     {
-        LOGF("error during reload: {}", e.what());
+        LOGFE("Database reload failed: {}", e.what());
         pkgi_dialog_error(
                 fmt::format(
                         "failed to reload db: {}, try to refresh?", e.what())
@@ -1072,7 +1163,7 @@ void pkgi_open_db()
     }
     catch (const std::exception& e)
     {
-        LOGF("error during database open: {}", e.what());
+        LOGFE("Database open failed: {}", e.what());
         throw formatEx<std::runtime_error>(
                 "DB initialization error: %s\nTry to delete them?");
     }
@@ -1081,8 +1172,10 @@ void pkgi_open_db()
 }
 }
 
-void pkgi_create_psp_rif(std::string contentid, uint8_t* rif)
+void pkgi_create_psp_rif([[maybe_unused]] std::string contentid,
+                         [[maybe_unused]] uint8_t* rif)
 {
+#ifndef PKGI_SIMULATOR
     SceNpDrmLicense license;
     memset(&license, 0x00, sizeof(SceNpDrmLicense));
     license.account_id = 0x0123456789ABCDEFLL;
@@ -1090,6 +1183,7 @@ void pkgi_create_psp_rif(std::string contentid, uint8_t* rif)
     strncpy(license.content_id, contentid.c_str(), 0x30);
 
     memcpy(rif, &license, PKGI_PSP_RIF_SIZE);
+#endif // PKGI_SIMULATOR
 }
 
 
@@ -1111,33 +1205,58 @@ void pkgi_download_psm_runtime_if_needed() {
 }
 
 
-void pkgi_start_download(Downloader& downloader, const DbItem& item)
+void pkgi_start_download(
+    Downloader& downloader,
+    const DbItem& item,
+    PspInstallMode psp_install_mode)
 {
     LOGF("[{}] {} - starting to install", item.content, item.name);
 
+#ifndef PKGI_SIMULATOR
     sceIoMkdir("ux0:bgdl", 0777);
+#else
+    pkgi_mkdirs("pkgj/bgdl");
+#endif
 
     try
     {
         // download PSM Runtime if a PSM game is requested to be installed ..
+#ifndef PKGI_SIMULATOR
         if(mode == ModePsmGames)
             pkgi_download_psm_runtime_if_needed();
+#endif
         // Just use the maximum size to be safe
         uint8_t rif[PKGI_PSM_RIF_SIZE];
         char message[256];
         if (item.zrif.empty() ||
             pkgi_zrif_decode(item.zrif.c_str(), rif, message, sizeof(message)))
         {
-            if ( 
-                mode == ModeGames || mode == ModeDlcs || mode == ModeDemos || mode == ModeThemes || // Vita contents
-                (MODE_IS_PSPEMU(mode) && pkgi_is_module_present("NoPspEmuDrm_kern")) || // Psp Contents
-                (mode == ModePsmGames && pkgi_is_module_present("NoPsmDrm")) // Psm Contents
-            )
-            {
+            const bool is_pspemudrm_mode = MODE_IS_PSPEMU(mode);
+#ifndef PKGI_SIMULATOR
+            const bool has_psp_bgdl =
+                    is_pspemudrm_mode && pkgi_is_module_present("NoPspEmuDrm_kern");
+            const bool use_psp_bgdl =
+                    is_pspemudrm_mode &&
+                    (psp_install_mode == PspInstallMode::LiveAreaPbp ||
+                     (psp_install_mode == PspInstallMode::Auto && has_psp_bgdl));
 
-                if (MODE_IS_PSPEMU(mode)) {
+            if (psp_install_mode == PspInstallMode::LiveAreaPbp && !has_psp_bgdl)
+                throw std::runtime_error(
+                        "NoPspEmuDrm is required to queue PSP installs in LiveArea");
+
+            if (
+                mode == ModeGames || mode == ModeDlcs || mode == ModeDemos || mode == ModeThemes ||
+                use_psp_bgdl ||
+                (mode == ModePsmGames && pkgi_is_module_present("NoPsmDrm")))
+            {
+                if (is_pspemudrm_mode) {
                     pkgi_create_psp_rif(item.content, rif);
                 }
+#else // PKGI_SIMULATOR — no bgdl / module checks; always direct download
+            [[maybe_unused]] const bool use_psp_bgdl = false;
+            if (mode == ModeGames || mode == ModeDlcs || mode == ModeDemos || mode == ModeThemes)
+            {
+#endif
                 
                 pkgi_start_bgdl(
                         mode_to_bgdl_type(mode),
@@ -1164,7 +1283,8 @@ void pkgi_start_download(Downloader& downloader, const DbItem& item)
                                                   item.digest.begin(),
                                                   item.digest.end())
                                         : std::vector<uint8_t>{},
-                        !config.install_psp_as_pbp,
+                        is_pspemudrm_mode &&
+                            psp_install_mode != PspInstallMode::LiveAreaPbp,
                         pkgi_get_mode_partition(),
                         ""});
             }
@@ -1207,7 +1327,7 @@ int main()
             pkgi_dialog_error(("Download failure: " + error).c_str());
         };
 
-        LOG("started");
+        LOG("PKGj started");
 
         config = pkgi_load_config();
         pkgi_dialog_init();
@@ -1218,7 +1338,15 @@ int main()
 
         pkgi_open_db();
 
+        annotation_db = std::make_unique<AnnotationDatabase>(
+                std::string(pkgi_get_config_folder()) + "/annotations.db");
+        pkgi_apply_annotations();
+
+#ifdef PKGI_SIMULATOR
+        pkgi_texture background = nullptr; // no embedded assets in simulator
+#else
         pkgi_texture background = pkgi_load_png(background);
+#endif
 
         if (!config.no_version_check)
             start_update_thread();
@@ -1231,6 +1359,7 @@ int main()
         // Build and load the texture atlas into a texture
         uint32_t* pixels = NULL;
         int width, height;
+#ifndef PKGI_SIMULATOR
         if (!io.Fonts->AddFontFromFileTTF(
                     "sa0:/data/font/pvf/ltn0.pvf",
                     20.0f,
@@ -1243,7 +1372,9 @@ int main()
                     0,
                     io.Fonts->GetGlyphRangesJapanese()))
             throw std::runtime_error("failed to load jpn0.pvf");
+#endif
         io.Fonts->GetTexDataAsRGBA32((uint8_t**)&pixels, &width, &height);
+#ifndef PKGI_SIMULATOR
         vita2d_texture* font_texture =
                 vita2d_create_empty_texture(width, height);
         const auto stride = vita2d_texture_get_stride(font_texture) / 4;
@@ -1254,6 +1385,10 @@ int main()
                 texture_data[y * stride + x] = pixels[y * width + x];
 
         io.Fonts->TexID = font_texture;
+#else // PKGI_SIMULATOR
+        io.Fonts->TexID = reinterpret_cast<ImTextureID>(
+                sim_create_font_texture(pixels, width, height));
+#endif // PKGI_SIMULATOR
 
         init_imgui();
 
@@ -1265,27 +1400,53 @@ int main()
             io.DisplaySize.x = VITA_WIDTH;
             io.DisplaySize.y = VITA_HEIGHT;
 
-            if (gameview || pkgi_dialog_is_open())
-            {
-                io.AddKeyEvent(
-                        ImGuiKey_GamepadDpadUp, input.pressed & PKGI_BUTTON_UP);
-                io.AddKeyEvent(
-                        ImGuiKey_GamepadDpadDown,
-                        input.pressed & PKGI_BUTTON_DOWN);
-                io.AddKeyEvent(
-                        ImGuiKey_GamepadDpadLeft,
-                        input.pressed & PKGI_BUTTON_LEFT);
-                io.AddKeyEvent(
-                        ImGuiKey_GamepadDpadRight,
-                        input.pressed & PKGI_BUTTON_RIGHT);
-                io.AddKeyEvent(
-                        ImGuiKey_GamepadFaceDown,
-                        input.pressed & pkgi_ok_button());
-                if (input.pressed & pkgi_cancel_button() && gameview)
-                    gameview->close();
+            // Snapshot for log viewer (needs raw input BEFORE zeroing)
+            const pkgi_input input_snapshot = input;
 
-                input.active = 0;
+            const bool has_imgui_overlay =
+                    gameview || config_editor || pkgi_dialog_is_open();
+
+            if (has_imgui_overlay || log_viewer)
+            {
+                // Feed D-pad to ImGui only for ImGui-managed overlays
+                if (has_imgui_overlay)
+                {
+                    io.AddKeyEvent(
+                            ImGuiKey_GamepadDpadUp,
+                            input.pressed & PKGI_BUTTON_UP);
+                    io.AddKeyEvent(
+                            ImGuiKey_GamepadDpadDown,
+                            input.pressed & PKGI_BUTTON_DOWN);
+                    io.AddKeyEvent(
+                            ImGuiKey_GamepadDpadLeft,
+                            input.pressed & PKGI_BUTTON_LEFT);
+                    io.AddKeyEvent(
+                            ImGuiKey_GamepadDpadRight,
+                            input.pressed & PKGI_BUTTON_RIGHT);
+                    io.AddKeyEvent(
+                            ImGuiKey_GamepadFaceDown,
+                            input.pressed & pkgi_ok_button());
+                }
+
+                // Universal cancel / save handlers (read pressed before zeroing)
+                if (input.pressed & pkgi_cancel_button())
+                {
+                    if (gameview)
+                        gameview->close();
+                    else if (config_editor)
+                        config_editor->close();
+                    else if (log_viewer)
+                        log_viewer->close();
+                }
+                if ((input.pressed & PKGI_BUTTON_T) && config_editor)
+                    config_editor->save_and_close();
+
+                input.active  = 0;
                 input.pressed = 0;
+                // input.down is NOT zeroed: sdl_backend needs it to track
+                // how long a key has been held (hold-repeat detection).
+                // Overlays consume input via input_snapshot (taken above);
+                // pkgi_do_main is inhibited by active == 0.
             }
 
             if (need_refresh)
@@ -1299,7 +1460,7 @@ int main()
                     if (item)
                         item->presence = PresenceUnknown;
                     else
-                        LOGF("couldn't find {} for refresh",
+                        LOGF("Post-download refresh: content ID {} not found in database",
                              content_to_refresh);
                     content_to_refresh.clear();
                 }
@@ -1335,9 +1496,43 @@ int main()
 
             if (gameview)
             {
-                gameview->render();
+                // Check is_closed() BEFORE render() so that when the view
+                // closes we do not add the texture to the ImGui draw list for
+                // this frame. The destructor calls vita2d_wait_rendering_done()
+                // which then safely covers the previous frame before freeing.
                 if (gameview->is_closed())
                     gameview = nullptr;
+                else
+                    gameview->render();
+            }
+
+            if (config_editor)
+            {
+                if (config_editor->is_closed())
+                {
+                    const bool saved = config_editor->was_saved();
+                    config_editor = nullptr;
+                    if (saved)
+                    {
+                        config = pkgi_load_config();
+                        config_temp = config;
+                        pkgi_reload();
+                        pkgi_mark_all_items_unknown();
+                        reposition();
+                    }
+                }
+                else
+                {
+                    config_editor->render();
+                }
+            }
+
+            if (log_viewer)
+            {
+                if (log_viewer->is_closed())
+                    log_viewer = nullptr;
+                else
+                    log_viewer->render(input_snapshot);
             }
 
             if (pkgi_dialog_is_open())
@@ -1345,7 +1540,8 @@ int main()
                 pkgi_do_dialog();
             }
 
-            if (pkgi_dialog_input_update())
+            if (!pkgi_overlay_is_open() && !pkgi_dialog_is_open() &&
+                    pkgi_dialog_input_update())
             {
                 search_active = 1;
                 pkgi_dialog_input_get_text(search_text, sizeof(search_text));
@@ -1429,6 +1625,12 @@ int main()
                     case MenuResultShowPspDlcs:
                         pkgi_set_mode(ModePspDlcs);
                         break;
+                    case MenuResultOpenConfigEditor:
+                        config_editor = std::make_unique<ConfigEditor>(config);
+                        break;
+                    case MenuResultOpenLogViewer:
+                        log_viewer = std::make_unique<LogViewer>();
+                        break;
                     }
                 }
             }
@@ -1443,7 +1645,7 @@ int main()
     }
     catch (const std::exception& e)
     {
-        LOGF("Error in main: {}", e.what());
+        LOGFE("Fatal error in main loop: {}", e.what());
         state = StateError;
         pkgi_snprintf(
                 error_state, sizeof(error_state), "Fatal error: %s", e.what());
@@ -1458,6 +1660,6 @@ int main()
         pkgi_end();
     }
 
-    LOG("finished");
+    LOG("PKGj shutting down");
     pkgi_end();
 }

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -50,9 +50,6 @@ extern SDL_Texture* sim_create_font_texture(const uint32_t* px, int w, int h);
 #include <cstddef>
 #include <cstring>
 
-#define PKGI_UPDATE_URL \
-    "https://api.github.com/repos/blastrock/pkgj/releases/latest"
-
 namespace
 {
 // forward declaration — defined later in this anonymous namespace

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -9,6 +9,7 @@ extern "C"
 #include "comppackdb.hpp"
 #include "config.hpp"
 #include "configeditor.hpp"
+#include "customhandler.hpp"
 #include "db.hpp"
 #include "dialog.hpp"
 #include "download.hpp"
@@ -18,6 +19,7 @@ extern "C"
 #include "install.hpp"
 #include "logviewer.hpp"
 #include "menu.hpp"
+#include "browserview.hpp"
 #include "update.hpp"
 #include "utils.hpp"
 #include "vitahttp.hpp"
@@ -59,10 +61,11 @@ typedef enum
 {
     StateError,
     StateRefreshing,
+    StateBrowse,
     StateMain,
 } State;
 
-State state = StateMain;
+State state = StateBrowse;
 Mode mode = ModeGames;
 
 uint32_t first_item;
@@ -95,6 +98,7 @@ std::set<std::string> installed_themes;
 std::unique_ptr<GameView> gameview;
 std::unique_ptr<ConfigEditor> config_editor;
 std::unique_ptr<LogViewer> log_viewer;
+std::unique_ptr<BrowseView> browse_view;
 std::unique_ptr<AnnotationDatabase> annotation_db;
 bool need_refresh = true;
 bool runtime_install_queued = false;
@@ -1180,8 +1184,7 @@ void pkgi_create_psp_rif([[maybe_unused]] std::string contentid,
     memset(&license, 0x00, sizeof(SceNpDrmLicense));
     license.account_id = 0x0123456789ABCDEFLL;
     memset(license.ecdsa_signature, 0xFF, 0x28);
-    strncpy(license.content_id, contentid.c_str(), 0x30);
-
+    snprintf(license.content_id, sizeof(license.content_id), "%s", contentid.c_str());
     memcpy(rif, &license, PKGI_PSP_RIF_SIZE);
 #endif // PKGI_SIMULATOR
 }
@@ -1338,6 +1341,26 @@ int main()
 
         pkgi_open_db();
 
+        browse_view = std::make_unique<BrowseView>(
+        config,
+                [](const BrowseNode& node)
+                {
+                    if (node.mode.has_value())
+                    {
+                        // Future: use node.group_filter to pre-filter the game
+                        // list by initial letter group (e.g. "A-D").
+                        pkgi_set_mode(*node.mode);
+                        state = StateMain;
+                        return;
+                    }
+
+                    if (!node.custom_tsv_url.empty())
+                    {
+                        pkgi_custom_open_list_template(
+                                node.label, node.custom_tsv_url);
+                    }
+                });
+
         annotation_db = std::make_unique<AnnotationDatabase>(
                 std::string(pkgi_get_config_folder()) + "/annotations.db");
         pkgi_apply_annotations();
@@ -1473,7 +1496,10 @@ int main()
 
             pkgi_draw_texture(background, 0, 0);
 
-            pkgi_do_head();
+            // Browse view renders its own header/footer; skip pkgi_do_head()
+            // in that state to avoid a conflicting title bar.
+            if (state != StateBrowse)
+                pkgi_do_head();
             switch (state)
             {
             case StateError:
@@ -1484,15 +1510,35 @@ int main()
                 pkgi_do_refresh();
                 break;
 
+            case StateBrowse:
+                // At the root of the browse tree, Back does nothing.
+                browse_view->update(input);
+                browse_view->render();
+                // Consume all input so menu / overlays do not react this frame.
+                input.active  = 0;
+                input.pressed = 0;
+                break;
+
             case StateMain:
                 pkgi_do_main(
                         downloader,
                         pkgi_dialog_is_open() || pkgi_menu_is_open() ? NULL
                                                                      : &input);
+                // Allow returning to the category tree with the cancel button
+                // when no overlay is active.
+                if (!pkgi_overlay_is_open() && !pkgi_dialog_is_open() &&
+                        !pkgi_menu_is_open() &&
+                        (input.pressed & pkgi_cancel_button()))
+                {
+                    state = StateBrowse;
+                    input.pressed &= ~pkgi_cancel_button();
+                }
                 break;
             }
 
-            pkgi_do_tail(downloader);
+            // Browse view draws its own footer; skip the game-list tail.
+            if (state != StateBrowse)
+                pkgi_do_tail(downloader);
 
             if (gameview)
             {
@@ -1600,6 +1646,9 @@ int main()
                         break;
                     case MenuResultRefresh:
                         pkgi_refresh_list();
+                        break;
+                    case MenuResultBackToBrowse:
+                        state = StateBrowse;
                         break;
                     case MenuResultShowGames:
                         pkgi_set_mode(ModeGames);

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -1614,12 +1614,15 @@ int main()
                     0,
                     io.Fonts->GetGlyphRangesDefault()))
             throw std::runtime_error("failed to load ltn0.pvf");
-        if (!io.Fonts->AddFontFromFileTTF(
+        {
+            ImFontConfig merge_cfg;
+            merge_cfg.MergeMode = true;
+            io.Fonts->AddFontFromFileTTF(
                     "sa0:/data/font/pvf/jpn0.pvf",
                     20.0f,
-                    0,
-                    io.Fonts->GetGlyphRangesJapanese()))
-            throw std::runtime_error("failed to load jpn0.pvf");
+                    &merge_cfg,
+                    io.Fonts->GetGlyphRangesJapanese());
+        }
 #endif
         io.Fonts->GetTexDataAsRGBA32((uint8_t**)&pixels, &width, &height);
 #ifndef PKGI_SIMULATOR

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -929,12 +929,11 @@ void pkgi_do_main(Downloader& downloader, pkgi_input* input)
         int h = static_cast<int>(pkgi_text_height("M") * scale);
         int text_top = (VITA_HEIGHT - h) / 2;
         int x = (VITA_WIDTH - w) / 2;
-        int y = text_top - 20;
-        if (y < 0)
-            y = 0;
+        int y = text_top;
         pkgi_draw_rect(x - 12, text_top - 12, w + 24, h + 24, PKGI_COLOR_MENU_BACKGROUND);
+        const uint32_t overlay_color = (0x33u << 24) | PKGI_COLOR_TEXT_HEAD;
         pkgi_draw_text_scale(
-                x, y, PKGI_COLOR_TEXT_HEAD, pkgi_group_overlay_text.c_str(), scale);
+                x, y, overlay_color, pkgi_group_overlay_text.c_str(), scale);
     }
 
     if (input && (input->pressed & pkgi_ok_button()))

--- a/src/pkgi.cpp
+++ b/src/pkgi.cpp
@@ -1683,7 +1683,10 @@ int main()
                 if (input.pressed & pkgi_cancel_button())
                 {
                     if (gameview)
-                        gameview->close();
+                    {
+                        if (!gameview->handle_cancel())
+                            gameview->close();
+                    }
                     else if (config_editor)
                         config_editor->close();
                     else if (log_viewer)

--- a/src/pkgi.hpp
+++ b/src/pkgi.hpp
@@ -112,6 +112,7 @@ void pkgi_clip_set(int x, int y, int w, int h);
 void pkgi_clip_remove(void);
 void pkgi_draw_rect(int x, int y, int w, int h, uint32_t color);
 void pkgi_draw_text(int x, int y, uint32_t color, const char* text);
+void pkgi_draw_text_scale(int x, int y, uint32_t color, const char* text, float scale);
 int pkgi_text_width(const char* text);
 int pkgi_text_height(const char* text);
 

--- a/src/pkgi.hpp
+++ b/src/pkgi.hpp
@@ -118,8 +118,18 @@ int pkgi_text_height(const char* text);
 class Downloader;
 struct DbItem;
 
+enum class PspInstallMode
+{
+    Auto,
+    Iso,
+    LiveAreaPbp,
+};
+
 void pkgi_create_psp_rif(std::string contentid, uint8_t* rif);
 
-void pkgi_start_download(Downloader& downloader, const DbItem& item);
+void pkgi_start_download(
+        Downloader& downloader,
+        const DbItem& item,
+        PspInstallMode psp_install_mode = PspInstallMode::Auto);
 
 bool pkgi_is_module_present(const char* module_name);

--- a/src/psx.cpp
+++ b/src/psx.cpp
@@ -31,8 +31,8 @@ std::string pkgi_pbp_read_disc_id(std::string eboot_pbp) {
     // check can open eboot file at all
     if(fd >= 0) {
         // check file is atleast size of pbp header
-        int read_sz = sceIoRead(fd, &pbp_hdr, sizeof(pbp_header));
-        if(read_sz >= sizeof(pbp_header)) {
+        SceSSize read_sz = sceIoRead(fd, &pbp_hdr, sizeof(pbp_header));
+        if(read_sz >= static_cast<SceSSize>(sizeof(pbp_header))) {
             // check magic is PBP magic
             if(memcmp(pbp_hdr.magic, "\0PBP", sizeof(pbp_hdr.magic)) == 0){
                 // check the param.sfo length is valid
@@ -45,7 +45,7 @@ std::string pkgi_pbp_read_disc_id(std::string eboot_pbp) {
                     read_sz = sceIoRead(fd, sfo, sfo_sz);
                     
                     // check read size is actually the size of the sfo
-                    if(read_sz >= sfo_sz) {
+                    if(read_sz >= 0 && static_cast<size_t>(read_sz) >= sfo_sz) {
                         disc_id = pkgi_sfo_get_string(sfo, sfo_sz, "DISC_ID");
                     }
                     
@@ -68,8 +68,8 @@ void pkgi_process_pbp(std::string eboot_pbp, std::string disc_id) {
     // check can open eboot file at all
     if(fd >= 0) {
         // check file is atleast size of pbp header
-        int read_sz = sceIoRead(fd, &pbp_hdr, sizeof(pbp_header));
-        if(read_sz >= sizeof(pbp_header)) {
+        SceSSize read_sz = sceIoRead(fd, &pbp_hdr, sizeof(pbp_header));
+        if(read_sz >= static_cast<SceSSize>(sizeof(pbp_header))) {
             // check magic is PBP magic
             if(memcmp(pbp_hdr.magic, "\0PBP", sizeof(pbp_hdr.magic)) == 0){
                 sceIoLseek(fd, pbp_hdr.data_psar, SCE_SEEK_SET);
@@ -78,7 +78,7 @@ void pkgi_process_pbp(std::string eboot_pbp, std::string disc_id) {
                 // check DATA.PSAR is atleast 8 bytes long
                 char magic[0x8];
                 read_sz = sceIoRead(fd, magic, sizeof(magic));
-                if(read_sz >= sizeof(magic)) {
+                if(read_sz >= static_cast<SceSSize>(sizeof(magic))) {
                     
                     // check is psx game
                     if(memcmp(magic, "PSISOIMG", sizeof(magic)) == 0 || memcmp(magic, "PSTITLEI", sizeof(magic)) == 0) {
@@ -88,7 +88,7 @@ void pkgi_process_pbp(std::string eboot_pbp, std::string disc_id) {
                         np_data_psp data_psp;
                         sceIoLseek(fd, pbp_hdr.data_psp, SCE_SEEK_SET);
                         read_sz = sceIoRead(fd, &data_psp, sizeof(np_data_psp));
-                        if(read_sz >= sizeof(np_data_psp)) {
+                        if(read_sz >= static_cast<SceSSize>(sizeof(np_data_psp))) {
                             // check the content id is the correct length
                             int cid_sz = strnlen(data_psp.content_id, 40);
                             if(cid_sz == 36) {

--- a/src/psx.cpp
+++ b/src/psx.cpp
@@ -73,7 +73,7 @@ void pkgi_process_pbp(std::string eboot_pbp, std::string disc_id) {
             // check magic is PBP magic
             if(memcmp(pbp_hdr.magic, "\0PBP", sizeof(pbp_hdr.magic)) == 0){
                 sceIoLseek(fd, pbp_hdr.data_psar, SCE_SEEK_SET);
-                LOGF("pbp_hdr magic is \"\\0PBP\"");
+                LOGF("Valid PBP header magic found");
                 
                 // check DATA.PSAR is atleast 8 bytes long
                 char magic[0x8];
@@ -82,7 +82,7 @@ void pkgi_process_pbp(std::string eboot_pbp, std::string disc_id) {
                     
                     // check is psx game
                     if(memcmp(magic, "PSISOIMG", sizeof(magic)) == 0 || memcmp(magic, "PSTITLEI", sizeof(magic)) == 0) {
-                        LOGF("data.psar magic is {}", std::string(magic, 8));
+                        LOGF("PSAR magic: {}", std::string(magic, 8));
                         
                         // check data.psp size is atleast the data.psp self header
                         np_data_psp data_psp;
@@ -94,7 +94,7 @@ void pkgi_process_pbp(std::string eboot_pbp, std::string disc_id) {
                             if(cid_sz == 36) {
                                 std::string title_id = std::string(data_psp.content_id + 7, 9);
                                 pkgi_psx_add_installed_game(title_id, disc_id);
-                                LOGF("Inserting {} = {}", title_id, disc_id);
+                                LOGF("Mapped PSX title ID {} to disc ID {}", title_id, disc_id);
                             }
                         }
                     }
@@ -115,8 +115,7 @@ void pkgi_scan_pbps() {
     std::string eboot_file;
     
     int dir_read_ret = 0;
-    SceIoDirent dir;
-    int ret = 0;
+    SceIoDirent dir;    
     do{
         memset(&dir, 0x00, sizeof(SceIoDirent));
         dir_read_ret = sceIoDread(dfd, &dir);    
@@ -125,7 +124,7 @@ void pkgi_scan_pbps() {
         std::string eboot_file = fmt::format("{}/{}/EBOOT.PBP", parent_folder, disc_id);
         pkgi_process_pbp(eboot_file, disc_id);
         
-        LOGF("checking {} .", eboot_file);
+        LOGF("Scanning PSX game folder: {}", eboot_file);
         
     } while(dir_read_ret > 0);
     

--- a/src/screenshotfetcher.cpp
+++ b/src/screenshotfetcher.cpp
@@ -6,6 +6,7 @@
 #include "pkgi.hpp"
 
 #include <fmt/format.h>
+#include <mutex>
 #include <vector>
 
 #ifndef PKGI_SIMULATOR

--- a/src/screenshotfetcher.cpp
+++ b/src/screenshotfetcher.cpp
@@ -5,7 +5,6 @@
 #include "log.hpp"
 #include "pkgi.hpp"
 
-#include <chrono>
 #include <fmt/format.h>
 #include <vector>
 
@@ -25,7 +24,7 @@ static vita2d_texture* sim_ss_load_jpeg(const char* path)
     SDL_FreeSurface(s);
     return reinterpret_cast<vita2d_texture*>(t);
 }
-#define vita2d_load_JPEG_file(p) sim_ss_load_jpeg(p)
+#define vita2d_load_JPEG_file(p)     sim_ss_load_jpeg(p)
 #define vita2d_wait_rendering_done() ((void)0)
 #define vita2d_free_texture(t) \
     SDL_DestroyTexture(reinterpret_cast<SDL_Texture*>(t))
@@ -33,6 +32,8 @@ static vita2d_texture* sim_ss_load_jpeg(const char* path)
 
 namespace
 {
+// ── Region helpers ────────────────────────────────────────────────────────────
+
 static std::string ss_get_country(const DbItem* item)
 {
     switch (pkgi_get_region(item->titleid))
@@ -66,167 +67,304 @@ static std::string ss_get_language(const DbItem* item)
         return "en";
     }
 }
+
+// ── JSON screenshot URL extractor ────────────────────────────────────────────
+// Parses the "images" array from a chihiro container JSON response.
+// The first entry in the array is typically the cover / box-art — we skip it
+// and return up to max_count subsequent image URLs as screenshots.
+static std::vector<std::string> extract_screenshot_urls(
+        const std::string& json, int max_count)
+{
+    std::vector<std::string> result;
+
+    // Find the "images" key and its array opening bracket.
+    auto pos = json.find("\"images\"");
+    if (pos == std::string::npos)
+        return result;
+    pos = json.find('[', pos);
+    if (pos == std::string::npos)
+        return result;
+    ++pos; // step past '['
+
+    int img_index = 0;
+    while (pos < json.size() && (int)result.size() < max_count)
+    {
+        // Advance to the next '{' (image object start) or ']' (array end).
+        while (pos < json.size() && json[pos] != '{' && json[pos] != ']')
+            ++pos;
+        if (pos >= json.size() || json[pos] == ']')
+            break;
+
+        ++pos; // skip '{'
+
+        // Find matching '}' — depth-aware, string-aware.
+        const size_t obj_start = pos;
+        int          depth     = 1;
+        bool         in_str    = false;
+        bool         esc       = false;
+        while (pos < json.size() && depth > 0)
+        {
+            char c = json[pos];
+            if (esc)
+                esc = false;
+            else if (c == '\\' && in_str)
+                esc = true;
+            else if (c == '"')
+                in_str = !in_str;
+            else if (!in_str)
+            {
+                if (c == '{')
+                    ++depth;
+                else if (c == '}')
+                    --depth;
+            }
+            ++pos;
+        }
+        // obj_start .. pos-1 is the object body (without enclosing braces).
+        const std::string obj = json.substr(obj_start, pos - 1 - obj_start);
+
+        // Extract the "url" field value from this object.
+        static const std::string URL_KEY = "\"url\":\"";
+        auto u = obj.find(URL_KEY);
+        if (u != std::string::npos)
+        {
+            u += URL_KEY.size();
+            std::string url;
+            bool        esc2 = false;
+            for (; u < obj.size(); ++u)
+            {
+                char c = obj[u];
+                if (esc2)
+                {
+                    url += c;
+                    esc2 = false;
+                }
+                else if (c == '\\')
+                    esc2 = true;
+                else if (c == '"')
+                    break;
+                else
+                    url += c;
+            }
+            // img_index == 0 → first image = cover art → skip.
+            if (img_index > 0 && !url.empty())
+                result.push_back(url);
+            ++img_index;
+        }
+    }
+    return result;
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+// Read all bytes from an already-started CurlHttp, up to max_bytes.
+static bool read_http_body(
+        CurlHttp& http, std::vector<uint8_t>& buf, size_t max_bytes)
+{
+    buf.clear();
+    buf.reserve(32 * 1024);
+    size_t pos = 0;
+    while (true)
+    {
+        if (pos == buf.size())
+            buf.resize(pos + 4096);
+        int64_t n = 0;
+        try
+        {
+            n = http.read(buf.data() + pos, buf.size() - pos);
+        }
+        catch (...)
+        {
+            break;
+        }
+        if (n == 0)
+            break;
+        pos += static_cast<size_t>(n);
+        if (pos > max_bytes)
+            break;
+    }
+    buf.resize(pos);
+    return pos > 0;
+}
+
+// Save data to path atomically (write .tmp then rename).
+static bool save_to_file(
+        const std::string& path, const std::vector<uint8_t>& data)
+{
+    void* f = nullptr;
+    try
+    {
+        const std::string tmp = path + ".tmp";
+        f                     = pkgi_create(tmp);
+        pkgi_write(f, data.data(), data.size());
+        pkgi_close(f);
+        f = nullptr;
+        pkgi_rename(tmp, path);
+        return true;
+    }
+    catch (...)
+    {
+        if (f)
+            pkgi_close(f);
+        return false;
+    }
+}
+
 } // namespace
 
+// ── ScreenshotFetcher ─────────────────────────────────────────────────────────
+
 ScreenshotFetcher::ScreenshotFetcher(const Config* config, const DbItem* item)
+    : _mutex("ss_fetcher_mutex")
+    , _thread("ss_fetcher", [this] { do_work(); })
 {
+    _titleid  = item->titleid;
+    _folder   = (config && !config->thumbnail_folder.empty())
+                ? config->thumbnail_folder
+                : "ux0:pkgj/cover";
+
     const auto country  = ss_get_country(item);
     const auto language = ss_get_language(item);
-
-    const std::string folder =
-            (config && !config->thumbnail_folder.empty())
-            ? config->thumbnail_folder
-            : "ux0:pkgj/cover";
-
-    for (int i = 0; i < MAX_SCREENSHOTS; ++i)
-    {
-        _paths[i]    = fmt::format("{}/{}.ss{}.jpg", folder, item->titleid, i);
-        _urls[i]     = fmt::format(
-                "https://store.playstation.com/store/api/chihiro/"
-                "00_09_000/container/{}/{}/19/{}/image"
-                "?w=240&h=136&thumb=true&index={}",
-                country,
-                language,
-                item->content,
-                i + 1);
-        _statuses[i] = Status::Pending;
-    }
+    _json_url = fmt::format(
+            "https://store.playstation.com/store/api/chihiro/"
+            "00_09_000/container/{}/{}/19/{}",
+            country,
+            language,
+            item->content);
 }
 
 ScreenshotFetcher::~ScreenshotFetcher()
 {
+    {
+        std::lock_guard<Mutex> lk(_mutex);
+        _abort = true;
+    }
+    _thread.join();
     vita2d_wait_rendering_done();
     for (int i = 0; i < MAX_SCREENSHOTS; ++i)
-        if (_textures[i])
-            vita2d_free_texture(_textures[i]);
+        if (_slots[i].texture)
+            vita2d_free_texture(_slots[i].texture);
 }
 
-void ScreenshotFetcher::_try_submit(int i)
+void ScreenshotFetcher::do_work()
 {
-    // Fast path: already cached on disc.
-    if (pkgi_file_exists(_paths[i].c_str()))
+    // ── Phase 1: download container JSON and extract screenshot URLs ──────────
     {
-        _pending_paths[i]  = _paths[i];
-        _upload_pending[i] = true;
-        _submitted[i]      = true;
+        std::lock_guard<Mutex> lk(_mutex);
+        if (_abort)
+            return;
+    }
+
+    CurlHttp json_http;
+    try
+    {
+        json_http.start(_json_url, 0);
+    }
+    catch (const std::exception& e)
+    {
+        LOGFW("[ScreenshotFetcher] JSON HTTP start failed for {}: {}",
+              _titleid,
+              e.what());
+        std::lock_guard<Mutex> lk(_mutex);
+        _json_done = true;
         return;
     }
 
-    // All captures by VALUE — lambda must not reference 'this'.
-    auto        result = std::make_shared<ImageFetchResult>();
-    std::string path   = _paths[i];
-    std::string url    = _urls[i];
-
-    if (!WorkerSlot::image_worker().try_submit(
-                path, // task_id = file path
-                [result, path, url]()
-                {
-                    using namespace std::chrono;
-                    const auto t0      = steady_clock::now();
-                    const auto timeout = seconds(8);
-
-                    auto done_error = [&]()
-                    {
-                        result->error = true;
-                        result->ready.store(true, std::memory_order_release);
-                    };
-                    auto done_ok = [&](std::string p)
-                    {
-                        result->error = false;
-                        result->path  = std::move(p);
-                        result->ready.store(true, std::memory_order_release);
-                    };
-
-                    CurlHttp http;
-                    try
-                    {
-                        http.start(url, 0);
-                    }
-                    catch (const std::exception& e)
-                    {
-                        LOGFW("[ScreenshotFetcher] HTTP start failed for {}: {}",
-                              path,
-                              e.what());
-                        done_error();
-                        return;
-                    }
-
-                    if (http.get_status() == 404)
-                    {
-                        done_error();
-                        return;
-                    }
-
-                    std::vector<uint8_t> data;
-                    data.reserve(16 * 1024);
-                    size_t pos = 0;
-                    while (true)
-                    {
-                        if (steady_clock::now() - t0 > timeout)
-                        {
-                            done_error();
-                            return;
-                        }
-                        if (pos == data.size())
-                            data.resize(pos + 4096);
-
-                        int64_t n = 0;
-                        try
-                        {
-                            n = http.read(
-                                    data.data() + pos, data.size() - pos);
-                        }
-                        catch (...)
-                        {
-                            done_error();
-                            return;
-                        }
-                        if (n == 0)
-                            break;
-                        pos += static_cast<size_t>(n);
-                        if (pos > ScreenshotFetcher::MAX_SIZE_BYTES)
-                        {
-                            done_error();
-                            return;
-                        }
-                    }
-
-                    if (pos == 0)
-                    {
-                        done_error();
-                        return;
-                    }
-                    data.resize(pos);
-
-                    void* f = nullptr;
-                    try
-                    {
-                        const std::string tmp = path + ".tmp";
-                        f                     = pkgi_create(tmp);
-                        pkgi_write(f, data.data(), data.size());
-                        pkgi_close(f);
-                        f = nullptr;
-                        pkgi_rename(tmp, path);
-                        done_ok(path);
-                    }
-                    catch (const std::exception& e)
-                    {
-                        if (f)
-                            pkgi_close(f);
-                        LOGFW("[ScreenshotFetcher] save failed for {}: {}",
-                              path,
-                              e.what());
-                        done_error();
-                    }
-                }))
+    if (json_http.get_status() != 200)
     {
-        // Slot busy — keep _submitted[i] false and retry next frame.
+        LOGFW("[ScreenshotFetcher] JSON HTTP {} for {}", json_http.get_status(),
+              _titleid);
+        std::lock_guard<Mutex> lk(_mutex);
+        _json_done = true;
         return;
     }
 
-    _results[i]   = std::move(result);
-    _submitted[i] = true;
-    _statuses[i]  = Status::Downloading;
+    std::vector<uint8_t> json_buf;
+    read_http_body(json_http, json_buf, 512 * 1024);
+    const std::string json(
+            reinterpret_cast<const char*>(json_buf.data()), json_buf.size());
+
+    const auto urls = extract_screenshot_urls(json, MAX_SCREENSHOTS);
+
+    {
+        std::lock_guard<Mutex> lk(_mutex);
+        _count    = static_cast<int>(urls.size());
+        _json_done = true;
+        if (urls.empty())
+        {
+            LOGF("[ScreenshotFetcher] no screenshots found in JSON for {}",
+                 _titleid);
+            return;
+        }
+    }
+
+    // ── Phase 2: download each screenshot image sequentially ─────────────────
+    for (int i = 0; i < (int)urls.size() && i < MAX_SCREENSHOTS; ++i)
+    {
+        {
+            std::lock_guard<Mutex> lk(_mutex);
+            if (_abort)
+                return;
+            _slots[i].status = Status::Downloading;
+        }
+
+        const std::string path =
+                fmt::format("{}/{}.ss{}.jpg", _folder, _titleid, i);
+
+        // Serve from disk cache if available.
+        if (pkgi_file_exists(path.c_str()))
+        {
+            std::lock_guard<Mutex> lk(_mutex);
+            _slots[i].path           = path;
+            _slots[i].upload_pending = true;
+            continue;
+        }
+
+        // Download from the URL extracted from the JSON.
+        CurlHttp img_http;
+        try
+        {
+            img_http.start(urls[i], 0);
+        }
+        catch (const std::exception& e)
+        {
+            LOGFW("[ScreenshotFetcher] image {} HTTP start failed: {}",
+                  i, e.what());
+            std::lock_guard<Mutex> lk(_mutex);
+            _slots[i].status = Status::Error;
+            continue;
+        }
+
+        if (img_http.get_status() == 404)
+        {
+            std::lock_guard<Mutex> lk(_mutex);
+            _slots[i].status = Status::Error;
+            continue;
+        }
+
+        std::vector<uint8_t> img_buf;
+        read_http_body(img_http, img_buf, MAX_SIZE_BYTES);
+
+        if (img_buf.empty())
+        {
+            std::lock_guard<Mutex> lk(_mutex);
+            _slots[i].status = Status::Error;
+            continue;
+        }
+
+        if (!save_to_file(path, img_buf))
+        {
+            std::lock_guard<Mutex> lk(_mutex);
+            _slots[i].status = Status::Error;
+            continue;
+        }
+
+        {
+            std::lock_guard<Mutex> lk(_mutex);
+            _slots[i].path           = path;
+            _slots[i].upload_pending = true;
+        }
+    }
 }
 
 ScreenshotFetcher::Status ScreenshotFetcher::get_status(int index)
@@ -234,44 +372,14 @@ ScreenshotFetcher::Status ScreenshotFetcher::get_status(int index)
     if (index < 0 || index >= MAX_SCREENSHOTS)
         return Status::Error;
 
-    // If a prior index returned 404, stop trying subsequent ones.
-    if (_stopped && !_submitted[index])
-    {
-        _statuses[index] = Status::Error;
-        return Status::Error;
-    }
+    std::lock_guard<Mutex> lk(_mutex);
 
-    if (!_submitted[index])
-    {
-        // Only start screenshot[i] after screenshot[i-1] has resolved,
-        // so we load them sequentially and stop cleanly on 404.
-        const bool prev_done = (index == 0) ||
-                               (_submitted[index - 1] &&
-                                _statuses[index - 1] != Status::Pending &&
-                                _statuses[index - 1] != Status::Downloading);
-        if (prev_done)
-            _try_submit(index);
-        return _statuses[index];
-    }
+    // Once JSON parsing is done, slots beyond what was found are errors.
+    if (_json_done && index >= _count &&
+        _slots[index].status == Status::Pending)
+        _slots[index].status = Status::Error;
 
-    // Poll worker result.
-    if (_results[index] &&
-        _results[index]->ready.load(std::memory_order_acquire))
-    {
-        if (_results[index]->error || _results[index]->path.empty())
-        {
-            _statuses[index] = Status::Error;
-            _stopped         = true; // don't try higher indices
-        }
-        else
-        {
-            _pending_paths[index]  = std::move(_results[index]->path);
-            _upload_pending[index] = true;
-        }
-        _results[index].reset();
-    }
-
-    return _statuses[index];
+    return _slots[index].status;
 }
 
 vita2d_texture* ScreenshotFetcher::get_texture(int index)
@@ -279,29 +387,38 @@ vita2d_texture* ScreenshotFetcher::get_texture(int index)
     if (index < 0 || index >= MAX_SCREENSHOTS)
         return nullptr;
 
-    get_status(index); // drive the pipeline
+    // Check (and consume) upload_pending under the mutex.
+    std::string path_to_load;
+    {
+        std::lock_guard<Mutex> lk(_mutex);
 
-    if (!_upload_pending[index])
-        return _textures[index];
+        // Also drive the JSON-done → Error transition.
+        if (_json_done && index >= _count &&
+            _slots[index].status == Status::Pending)
+            _slots[index].status = Status::Error;
 
-    _upload_pending[index]  = false;
-    const std::string path = std::move(_pending_paths[index]);
+        if (!_slots[index].upload_pending)
+            return _slots[index].texture;
 
-    vita2d_texture* tex = vita2d_load_JPEG_file(path.c_str());
+        _slots[index].upload_pending = false;
+        path_to_load                 = _slots[index].path;
+    }
+
+    // Load the JPEG on the main thread (vita2d requirement).
+    vita2d_texture* tex = vita2d_load_JPEG_file(path_to_load.c_str());
     if (!tex)
     {
-        LOGFW("[ScreenshotFetcher] vita2d_load_JPEG_file failed for {}, "
-              "removing",
-              path);
-        pkgi_rm(path.c_str());
-        _statuses[index] = Status::Error;
-        _stopped         = true;
-    }
-    else
-    {
-        _statuses[index] = Status::Ready;
+        LOGFW("[ScreenshotFetcher] vita2d_load_JPEG_file failed for {}",
+              path_to_load);
+        pkgi_rm(path_to_load.c_str());
+        std::lock_guard<Mutex> lk(_mutex);
+        _slots[index].status = Status::Error;
+        return nullptr;
     }
 
-    _textures[index] = tex;
+    std::lock_guard<Mutex> lk(_mutex);
+    _slots[index].texture = tex;
+    _slots[index].status  = Status::Ready;
     return tex;
 }
+

--- a/src/screenshotfetcher.cpp
+++ b/src/screenshotfetcher.cpp
@@ -1,0 +1,307 @@
+#include "screenshotfetcher.hpp"
+
+#include "curlhttp.hpp"
+#include "file.hpp"
+#include "log.hpp"
+#include "pkgi.hpp"
+
+#include <chrono>
+#include <fmt/format.h>
+#include <vector>
+
+#ifndef PKGI_SIMULATOR
+#include <vita2d.h>
+#else
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+extern SDL_Renderer* g_sdl_renderer;
+
+static vita2d_texture* sim_ss_load_jpeg(const char* path)
+{
+    SDL_Surface* s = IMG_Load(path);
+    if (!s)
+        return nullptr;
+    SDL_Texture* t = SDL_CreateTextureFromSurface(g_sdl_renderer, s);
+    SDL_FreeSurface(s);
+    return reinterpret_cast<vita2d_texture*>(t);
+}
+#define vita2d_load_JPEG_file(p) sim_ss_load_jpeg(p)
+#define vita2d_wait_rendering_done() ((void)0)
+#define vita2d_free_texture(t) \
+    SDL_DestroyTexture(reinterpret_cast<SDL_Texture*>(t))
+#endif
+
+namespace
+{
+static std::string ss_get_country(const DbItem* item)
+{
+    switch (pkgi_get_region(item->titleid))
+    {
+    case RegionASA:
+        if (item->name.find("CHN") != std::string::npos)
+            return "CN";
+        if (item->content.size() >= 6 && item->content.substr(0, 6) == "HP0507")
+            return "KR";
+        return "HK";
+    case RegionJPN:
+        return "JP";
+    case RegionEUR:
+        return "GB";
+    default:
+        return "US";
+    }
+}
+
+static std::string ss_get_language(const DbItem* item)
+{
+    switch (pkgi_get_region(item->titleid))
+    {
+    case RegionASA:
+        if (item->content.size() >= 6 && item->content.substr(0, 6) == "HP0507")
+            return "ko";
+        return "zh";
+    case RegionJPN:
+        return "ja";
+    default:
+        return "en";
+    }
+}
+} // namespace
+
+ScreenshotFetcher::ScreenshotFetcher(const Config* config, const DbItem* item)
+{
+    const auto country  = ss_get_country(item);
+    const auto language = ss_get_language(item);
+
+    const std::string folder =
+            (config && !config->thumbnail_folder.empty())
+            ? config->thumbnail_folder
+            : "ux0:pkgj/cover";
+
+    for (int i = 0; i < MAX_SCREENSHOTS; ++i)
+    {
+        _paths[i]    = fmt::format("{}/{}.ss{}.jpg", folder, item->titleid, i);
+        _urls[i]     = fmt::format(
+                "https://store.playstation.com/store/api/chihiro/"
+                "00_09_000/container/{}/{}/19/{}/image"
+                "?w=240&h=136&thumb=true&index={}",
+                country,
+                language,
+                item->content,
+                i + 1);
+        _statuses[i] = Status::Pending;
+    }
+}
+
+ScreenshotFetcher::~ScreenshotFetcher()
+{
+    vita2d_wait_rendering_done();
+    for (int i = 0; i < MAX_SCREENSHOTS; ++i)
+        if (_textures[i])
+            vita2d_free_texture(_textures[i]);
+}
+
+void ScreenshotFetcher::_try_submit(int i)
+{
+    // Fast path: already cached on disc.
+    if (pkgi_file_exists(_paths[i].c_str()))
+    {
+        _pending_paths[i]  = _paths[i];
+        _upload_pending[i] = true;
+        _submitted[i]      = true;
+        return;
+    }
+
+    // All captures by VALUE — lambda must not reference 'this'.
+    auto        result = std::make_shared<ImageFetchResult>();
+    std::string path   = _paths[i];
+    std::string url    = _urls[i];
+
+    if (!WorkerSlot::image_worker().try_submit(
+                path, // task_id = file path
+                [result, path, url]()
+                {
+                    using namespace std::chrono;
+                    const auto t0      = steady_clock::now();
+                    const auto timeout = seconds(8);
+
+                    auto done_error = [&]()
+                    {
+                        result->error = true;
+                        result->ready.store(true, std::memory_order_release);
+                    };
+                    auto done_ok = [&](std::string p)
+                    {
+                        result->error = false;
+                        result->path  = std::move(p);
+                        result->ready.store(true, std::memory_order_release);
+                    };
+
+                    CurlHttp http;
+                    try
+                    {
+                        http.start(url, 0);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        LOGFW("[ScreenshotFetcher] HTTP start failed for {}: {}",
+                              path,
+                              e.what());
+                        done_error();
+                        return;
+                    }
+
+                    if (http.get_status() == 404)
+                    {
+                        done_error();
+                        return;
+                    }
+
+                    std::vector<uint8_t> data;
+                    data.reserve(16 * 1024);
+                    size_t pos = 0;
+                    while (true)
+                    {
+                        if (steady_clock::now() - t0 > timeout)
+                        {
+                            done_error();
+                            return;
+                        }
+                        if (pos == data.size())
+                            data.resize(pos + 4096);
+
+                        int64_t n = 0;
+                        try
+                        {
+                            n = http.read(
+                                    data.data() + pos, data.size() - pos);
+                        }
+                        catch (...)
+                        {
+                            done_error();
+                            return;
+                        }
+                        if (n == 0)
+                            break;
+                        pos += static_cast<size_t>(n);
+                        if (pos > ScreenshotFetcher::MAX_SIZE_BYTES)
+                        {
+                            done_error();
+                            return;
+                        }
+                    }
+
+                    if (pos == 0)
+                    {
+                        done_error();
+                        return;
+                    }
+                    data.resize(pos);
+
+                    void* f = nullptr;
+                    try
+                    {
+                        const std::string tmp = path + ".tmp";
+                        f                     = pkgi_create(tmp);
+                        pkgi_write(f, data.data(), data.size());
+                        pkgi_close(f);
+                        f = nullptr;
+                        pkgi_rename(tmp, path);
+                        done_ok(path);
+                    }
+                    catch (const std::exception& e)
+                    {
+                        if (f)
+                            pkgi_close(f);
+                        LOGFW("[ScreenshotFetcher] save failed for {}: {}",
+                              path,
+                              e.what());
+                        done_error();
+                    }
+                }))
+    {
+        // Slot busy — keep _submitted[i] false and retry next frame.
+        return;
+    }
+
+    _results[i]   = std::move(result);
+    _submitted[i] = true;
+    _statuses[i]  = Status::Downloading;
+}
+
+ScreenshotFetcher::Status ScreenshotFetcher::get_status(int index)
+{
+    if (index < 0 || index >= MAX_SCREENSHOTS)
+        return Status::Error;
+
+    // If a prior index returned 404, stop trying subsequent ones.
+    if (_stopped && !_submitted[index])
+    {
+        _statuses[index] = Status::Error;
+        return Status::Error;
+    }
+
+    if (!_submitted[index])
+    {
+        // Only start screenshot[i] after screenshot[i-1] has resolved,
+        // so we load them sequentially and stop cleanly on 404.
+        const bool prev_done = (index == 0) ||
+                               (_submitted[index - 1] &&
+                                _statuses[index - 1] != Status::Pending &&
+                                _statuses[index - 1] != Status::Downloading);
+        if (prev_done)
+            _try_submit(index);
+        return _statuses[index];
+    }
+
+    // Poll worker result.
+    if (_results[index] &&
+        _results[index]->ready.load(std::memory_order_acquire))
+    {
+        if (_results[index]->error || _results[index]->path.empty())
+        {
+            _statuses[index] = Status::Error;
+            _stopped         = true; // don't try higher indices
+        }
+        else
+        {
+            _pending_paths[index]  = std::move(_results[index]->path);
+            _upload_pending[index] = true;
+        }
+        _results[index].reset();
+    }
+
+    return _statuses[index];
+}
+
+vita2d_texture* ScreenshotFetcher::get_texture(int index)
+{
+    if (index < 0 || index >= MAX_SCREENSHOTS)
+        return nullptr;
+
+    get_status(index); // drive the pipeline
+
+    if (!_upload_pending[index])
+        return _textures[index];
+
+    _upload_pending[index]  = false;
+    const std::string path = std::move(_pending_paths[index]);
+
+    vita2d_texture* tex = vita2d_load_JPEG_file(path.c_str());
+    if (!tex)
+    {
+        LOGFW("[ScreenshotFetcher] vita2d_load_JPEG_file failed for {}, "
+              "removing",
+              path);
+        pkgi_rm(path.c_str());
+        _statuses[index] = Status::Error;
+        _stopped         = true;
+    }
+    else
+    {
+        _statuses[index] = Status::Ready;
+    }
+
+    _textures[index] = tex;
+    return tex;
+}

--- a/src/screenshotfetcher.hpp
+++ b/src/screenshotfetcher.hpp
@@ -2,8 +2,7 @@
 
 #include "config.hpp"
 #include "db.hpp"
-#include "imagefetcher.hpp" // ImageFetchResult
-#include "workerpool.hpp"
+#include "thread.hpp"
 
 #ifndef PKGI_SIMULATOR
 #include <vita2d.h>
@@ -11,19 +10,20 @@
 struct vita2d_texture;
 #endif
 
-#include <memory>
 #include <string>
 
-// Fetches up to MAX_SCREENSHOTS thumbnail screenshots for a game from the
-// PlayStation Store chihiro API.  Shares the global WorkerSlot with
-// ImageFetcher — downloads are queued sequentially.
+// Fetches screenshots for a game from the PlayStation Store chihiro API.
+// Phase 1: downloads the container JSON to discover actual screenshot URLs
+// (skipping the first image, which is typically the cover / box-art).
+// Phase 2: downloads each screenshot image sequentially and caches to disk.
 //
-// All public methods must be called from the MAIN thread.
+// All public methods (get_status, get_texture) must be called from the
+// MAIN thread only.
 class ScreenshotFetcher
 {
 public:
     static constexpr int    MAX_SCREENSHOTS = 4;
-    static constexpr size_t MAX_SIZE_BYTES  = 200 * 1024; // 200 KB per image
+    static constexpr size_t MAX_SIZE_BYTES  = 256 * 1024; // 256 KB per image
 
     enum class Status
     {
@@ -36,24 +36,31 @@ public:
     ScreenshotFetcher(const Config* config, const DbItem* item);
     ~ScreenshotFetcher();
 
-    // Drive the download and upload pipeline.  Must be called every frame.
+    // Returns the texture for 'index', or nullptr if not ready / error.
+    // Also drives the texture-upload step (must be called every frame).
     vita2d_texture* get_texture(int index);
     Status          get_status(int index);
 
 private:
-    std::string _paths[MAX_SCREENSHOTS];
-    std::string _urls[MAX_SCREENSHOTS];
+    struct Slot
+    {
+        Status          status{Status::Pending};
+        std::string     path;            // cache file path (set under mutex)
+        vita2d_texture* texture{nullptr};
+        bool            upload_pending{false}; // file ready, needs vita2d load
+    };
 
-    bool   _submitted[MAX_SCREENSHOTS]{};
-    Status _statuses[MAX_SCREENSHOTS];
-    bool   _stopped{false}; // true after first 404 — don't try higher indices
+    std::string _titleid;
+    std::string _folder;   // cache directory
+    std::string _json_url; // chihiro container URL (returns JSON)
 
-    std::shared_ptr<ImageFetchResult> _results[MAX_SCREENSHOTS];
-    vita2d_texture*                   _textures[MAX_SCREENSHOTS]{};
-    bool                              _upload_pending[MAX_SCREENSHOTS]{};
-    std::string                       _pending_paths[MAX_SCREENSHOTS];
+    Slot _slots[MAX_SCREENSHOTS];
+    int  _count{0};        // screenshot count discovered from JSON (0 until known)
+    bool _json_done{false};
 
-    // Tries to hand screenshot[i] to WorkerSlot::image_worker().
-    // Returns immediately if the slot is busy; caller retries next frame.
-    void _try_submit(int i);
+    Mutex  _mutex;
+    bool   _abort{false};
+    Thread _thread;
+
+    void do_work(); // runs on background thread
 };

--- a/src/screenshotfetcher.hpp
+++ b/src/screenshotfetcher.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "config.hpp"
+#include "db.hpp"
+#include "imagefetcher.hpp" // ImageFetchResult
+#include "workerpool.hpp"
+
+#ifndef PKGI_SIMULATOR
+#include <vita2d.h>
+#else
+struct vita2d_texture;
+#endif
+
+#include <memory>
+#include <string>
+
+// Fetches up to MAX_SCREENSHOTS thumbnail screenshots for a game from the
+// PlayStation Store chihiro API.  Shares the global WorkerSlot with
+// ImageFetcher — downloads are queued sequentially.
+//
+// All public methods must be called from the MAIN thread.
+class ScreenshotFetcher
+{
+public:
+    static constexpr int    MAX_SCREENSHOTS = 4;
+    static constexpr size_t MAX_SIZE_BYTES  = 200 * 1024; // 200 KB per image
+
+    enum class Status
+    {
+        Pending,
+        Downloading,
+        Ready,
+        Error,
+    };
+
+    ScreenshotFetcher(const Config* config, const DbItem* item);
+    ~ScreenshotFetcher();
+
+    // Drive the download and upload pipeline.  Must be called every frame.
+    vita2d_texture* get_texture(int index);
+    Status          get_status(int index);
+
+private:
+    std::string _paths[MAX_SCREENSHOTS];
+    std::string _urls[MAX_SCREENSHOTS];
+
+    bool   _submitted[MAX_SCREENSHOTS]{};
+    Status _statuses[MAX_SCREENSHOTS];
+    bool   _stopped{false}; // true after first 404 — don't try higher indices
+
+    std::shared_ptr<ImageFetchResult> _results[MAX_SCREENSHOTS];
+    vita2d_texture*                   _textures[MAX_SCREENSHOTS]{};
+    bool                              _upload_pending[MAX_SCREENSHOTS]{};
+    std::string                       _pending_paths[MAX_SCREENSHOTS];
+
+    // Tries to hand screenshot[i] to WorkerSlot::image_worker().
+    // Returns immediately if the slot is busy; caller retries next frame.
+    void _try_submit(int i);
+};

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -4,6 +4,8 @@ extern "C"
 #include "style.h"
 }
 
+#include "logbuffer.hpp"
+
 #include <fmt/format.h>
 
 #include <boost/scope_exit.hpp>
@@ -25,13 +27,23 @@ extern "C"
 #define PKGI_FOLDER "pkgi"
 #define PKGI_APP_FOLDER "app"
 
-void pkgi_log(const char* msg, ...)
+void pkgi_log(LogLevel level, const char* msg, ...)
 {
+    char buffer[512];
+
     va_list args;
     va_start(args, msg);
-    vprintf(msg, args);
-    printf("\n");
+    int len = vsnprintf(buffer, sizeof(buffer), msg, args);
     va_end(args);
+
+    if (len < 0)
+        len = 0;
+    else if (len >= static_cast<int>(sizeof(buffer)))
+        len = sizeof(buffer) - 1;
+    buffer[len] = 0;
+
+    pkgi_log_buffer_append(level, buffer);
+    printf("%s\n", buffer);
 }
 
 int pkgi_snprintf(char* buffer, uint32_t size, const char* msg, ...)
@@ -125,7 +137,7 @@ void pkgi_mkdirs(const char* ppath)
 
         char last = *ptr;
         *ptr = 0;
-        LOG("mkdir %s", path.c_str());
+        LOG("Creating directory: %s", path.c_str());
         int err = mkdir(path.c_str(), 0777);
         if (err < 0 && errno != EEXIST)
             throw std::runtime_error(fmt::format(
@@ -301,7 +313,7 @@ void pkgi_save(const std::string& path, const void* data, uint32_t size)
 
 void* pkgi_create(const std::string& path)
 {
-    LOGF("pkgi_create {}", path);
+    LOGF("Creating file: {}", path);
     int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
     if (fd < 0)
         throw std::runtime_error("pkgi_create failed");

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -2,12 +2,110 @@
 
 #include "pkgi.hpp"
 
+#ifndef PKGI_SIMULATOR
 #include <psp2/kernel/threadmgr.h>
+#endif // PKGI_SIMULATOR
 
 #include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
+
+#ifdef PKGI_SIMULATOR
+// ──────────────────────────────────────────────────────────────────────────────
+// Linux / simulator implementations using std::mutex + std::thread
+// ──────────────────────────────────────────────────────────────────────────────
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+class ScopeProcessLock
+{
+public:
+    ScopeProcessLock(const ScopeProcessLock&) = delete;
+    ScopeProcessLock(ScopeProcessLock&&) = delete;
+    ScopeProcessLock& operator=(const ScopeProcessLock&) = delete;
+    ScopeProcessLock& operator=(ScopeProcessLock&&) = delete;
+
+    ScopeProcessLock()  { pkgi_lock_process(); }
+    ~ScopeProcessLock() { pkgi_unlock_process(); }
+};
+
+class Mutex
+{
+public:
+    Mutex(const Mutex&) = delete;
+    Mutex(Mutex&&) = delete;
+    Mutex& operator=(const Mutex&) = delete;
+    Mutex& operator=(Mutex&&) = delete;
+
+    explicit Mutex(const std::string& /*name*/) {}
+
+    void lock()     { _m.lock(); }
+    bool try_lock() { return _m.try_lock(); }
+    void unlock()   { _m.unlock(); }
+
+private:
+    std::mutex _m;
+    friend class Cond;
+};
+
+class Cond
+{
+public:
+    Cond(const Cond&) = delete;
+    Cond(Cond&&) = delete;
+    Cond& operator=(const Cond&) = delete;
+    Cond& operator=(Cond&&) = delete;
+
+    explicit Cond(const std::string& name) : _mutex(name + "_mutex") {}
+
+    void notify_one()
+    {
+        _cv.notify_one();
+    }
+
+    void wait()
+    {
+        std::unique_lock<std::mutex> lk(_mutex._m, std::adopt_lock);
+        _cv.wait(lk);
+        lk.release(); // keep locked after wait
+    }
+
+    Mutex& get_mutex() { return _mutex; }
+
+private:
+    Mutex _mutex;
+    std::condition_variable _cv;
+};
+
+class Thread
+{
+public:
+    using EntryPoint = std::function<void()>;
+
+    Thread(const Thread&) = delete;
+    Thread(Thread&&) = delete;
+    Thread& operator=(const Thread&) = delete;
+    Thread& operator=(Thread&&) = delete;
+
+    Thread(const std::string& /*name*/, EntryPoint entry)
+        : _t(std::move(entry))
+    {}
+
+    ~Thread()
+    {
+        if (_t.joinable())
+            _t.detach();
+    }
+
+    void join() { _t.join(); }
+
+private:
+    std::thread _t;
+};
+
+#else // PKGI_SIMULATOR — original Vita implementation below
 
 class ScopeProcessLock
 {
@@ -43,7 +141,7 @@ public:
         if (res < 0)
         {
             // TODO throw
-            LOG("create mutex failed error=0x%08x", res);
+            LOG_ERR("Mutex creation failed: err=0x%08x", res);
         }
     }
 
@@ -53,7 +151,7 @@ public:
         if (res < 0)
         {
             // TODO assert
-            LOG("delete mutex failed error=0x%08x", res);
+            LOG_ERR("Mutex deletion failed: err=0x%08x", res);
         }
     }
 
@@ -63,7 +161,7 @@ public:
         if (res < 0)
         {
             // TODO throw
-            LOG("lock failed error=0x%08x", res);
+            LOG_ERR("Mutex lock failed: err=0x%08x", res);
         }
     }
 
@@ -85,7 +183,7 @@ public:
         if (res < 0)
         {
             // TODO throw
-            LOG("unlock failed error=0x%08x", res);
+            LOG_ERR("Mutex unlock failed: err=0x%08x", res);
         }
     }
 
@@ -110,7 +208,7 @@ public:
         if (res < 0)
         {
             // TODO throw
-            LOG("create cond failed error=0x%08x", res);
+            LOG_ERR("Condition variable creation failed: err=0x%08x", res);
         }
     }
 
@@ -120,7 +218,7 @@ public:
         if (res < 0)
         {
             // TODO assert
-            LOG("delete cond failed error=0x%08x", res);
+            LOG_ERR("Condition variable deletion failed: err=0x%08x", res);
         }
     }
 
@@ -130,7 +228,7 @@ public:
         if (res < 0)
         {
             // TODO throw
-            LOG("cond signal failed error=0x%08x", res);
+            LOG_ERR("Condition variable signal failed: err=0x%08x", res);
         }
     }
 
@@ -140,7 +238,7 @@ public:
         if (res < 0)
         {
             // TODO throw
-            LOG("wait cond failed error=0x%08x", res);
+            LOG_ERR("Condition variable wait failed: err=0x%08x", res);
         }
     }
 
@@ -171,7 +269,7 @@ public:
         if (_tid < 0)
         {
             // TODO throw
-            LOG("create thread failed error=0x%08x", _tid);
+            LOG_ERR("Thread creation failed: err=0x%08x", _tid);
         }
         auto entryp = new EntryPoint(std::move(entry));
         const auto res = sceKernelStartThread(_tid, sizeof(entryp), &entryp);
@@ -179,7 +277,7 @@ public:
         {
             delete entryp;
             // TODO throw
-            LOG("start thread failed error=0x%08x", res);
+            LOG_ERR("Thread start failed: err=0x%08x", res);
         }
     }
 
@@ -189,7 +287,7 @@ public:
         if (res < 0)
         {
             // TODO assert
-            LOG("thread delete failed error=0x%08x", res);
+            LOG_ERR("Thread deletion failed: err=0x%08x", res);
         }
     }
 
@@ -200,7 +298,7 @@ public:
         if (res < 0)
         {
             // TODO assert
-            LOG("thread join failed error=0x%08x", res);
+            LOG_ERR("Thread join failed: err=0x%08x", res);
         }
     }
 
@@ -214,16 +312,17 @@ private:
             auto entryp = std::unique_ptr<EntryPoint>(
                     *static_cast<EntryPoint**>(argp));
             (*entryp)();
-            LOG("thread successfully terminated");
+            LOG("Thread terminated successfully");
         }
         catch (const std::exception& e)
         {
-            LOG("got exception from thread: %s", e.what());
+            LOG_ERR("Thread terminated with exception: %s", e.what());
         }
         catch (...)
         {
-            LOG("got unknown exception from thread");
+            LOG_ERR("Thread terminated with unknown exception");
         }
         return 0;
     }
 };
+#endif // PKGI_SIMULATOR

--- a/src/thumbnailfetcher.cpp
+++ b/src/thumbnailfetcher.cpp
@@ -1,0 +1,193 @@
+#include "thumbnailfetcher.hpp"
+
+#include "file.hpp"
+#include "pkgi.hpp"
+#include "vitahttp.hpp"
+
+#ifndef PKGI_SIMULATOR
+#include <vita2d.h>
+#endif
+
+#include <chrono>
+#include <fmt/format.h>
+#include <mutex>
+
+#ifdef PKGI_SIMULATOR
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+extern SDL_Renderer* g_sdl_renderer;
+// SDL2 drop-in replacements for the vita2d JPEG loaders
+static vita2d_texture* sim_load_jpeg_file(const char* path)
+{
+    SDL_Surface* s = IMG_Load(path);
+    if (!s) return nullptr;
+    SDL_Texture* t = SDL_CreateTextureFromSurface(g_sdl_renderer, s);
+    SDL_FreeSurface(s);
+    return reinterpret_cast<vita2d_texture*>(t);
+}
+static vita2d_texture* sim_load_jpeg_buf(const void* data, size_t size)
+{
+    SDL_RWops* rw = SDL_RWFromConstMem(data, static_cast<int>(size));
+    SDL_Surface* s = rw ? IMG_Load_RW(rw, 1) : nullptr;
+    if (!s) return nullptr;
+    SDL_Texture* t = SDL_CreateTextureFromSurface(g_sdl_renderer, s);
+    SDL_FreeSurface(s);
+    return reinterpret_cast<vita2d_texture*>(t);
+}
+#define vita2d_load_JPEG_file(p)     sim_load_jpeg_file(p)
+#define vita2d_load_JPEG_buffer(d,n) sim_load_jpeg_buf(d,n)
+#endif
+
+ThumbnailFetcher::ThumbnailFetcher(
+        const std::string& titleid,
+        const std::string& folder,
+        const std::string& base_url)
+    : _mutex("thumbnail_fetcher_mutex")
+    , _path(fmt::format("{}/{}.jpg", folder, titleid))
+    , _url(base_url.empty() ? "" : fmt::format("{}/{}.jpg", base_url, titleid))
+    , _thread("thumbnail_fetcher", [this] { do_request(); })
+{
+    pkgi_mkdirs(folder.c_str());
+}
+
+ThumbnailFetcher::~ThumbnailFetcher()
+{
+    Http* http;
+    {
+        std::lock_guard<Mutex> lock(_mutex);
+        _abort = true;
+        http = _http.get();
+    }
+    if (http)
+        http->abort();
+    _thread.join();
+}
+
+vita2d_texture* ThumbnailFetcher::get_texture()
+{
+    std::lock_guard<Mutex> lock(_mutex);
+    return _texture;
+}
+
+void ThumbnailFetcher::do_request()
+{
+    using namespace std::chrono;
+    auto start_time = steady_clock::now();
+    const auto timeout = seconds(8);
+
+    try
+    {
+        // 1. Try loading from local cached file
+        if (pkgi_file_exists(_path.c_str()))
+        {
+            std::lock_guard<Mutex> lock(_mutex);
+            _texture = vita2d_load_JPEG_file(_path.c_str());
+            if (_texture)
+                return;
+            // File exists but failed to decode — fall through and re-download
+        }
+
+        // 2. No URL configured → nothing more to do
+        if (_url.empty())
+            return;
+
+        // 3. Abort check before network
+        {
+            std::lock_guard<Mutex> lock(_mutex);
+            if (_abort)
+                return;
+            _http = std::make_unique<VitaHttp>();
+        }
+
+        // 4. Open connection
+        _http->start(_url, 0);
+
+        if (_http->get_status() == 404)
+        {
+            LOGF("thumbnail not found (404): {}", _url);
+            std::lock_guard<Mutex> lock(_mutex);
+            _http = nullptr;
+            return;
+        }
+
+        // 5. Download with hard 100 KB size cap
+        std::vector<uint8_t> data;
+        data.reserve(32 * 1024);
+        size_t pos = 0;
+        bool too_large = false;
+
+        while (true)
+        {
+            // Timeout check
+            if (steady_clock::now() - start_time > timeout)
+            {
+                LOGFW("thumbnail fetch timed out after {} seconds: {}", timeout.count(), _url);
+                std::lock_guard<Mutex> lock(_mutex);
+                _http = nullptr;
+                return;
+            }
+
+            // Check abort between each chunk
+            {
+                std::lock_guard<Mutex> lock(_mutex);
+                if (_abort)
+                {
+                    _http = nullptr;
+                    return;
+                }
+            }
+
+            if (pos == data.size())
+                data.resize(pos + 4096);
+
+            const auto read = _http->read(data.data() + pos, data.size() - pos);
+            if (read == 0)
+                break;
+            pos += read;
+
+            if (pos > MAX_SIZE_BYTES)
+            {
+                too_large = true;
+                LOGFW("thumbnail exceeds {} KB, aborting download: {}",
+                     MAX_SIZE_BYTES / 1024,
+                     _url);
+                break;
+            }
+        }
+
+        {
+            std::lock_guard<Mutex> lock(_mutex);
+            _http = nullptr;
+        }
+
+        if (too_large || data.empty())
+            return;
+
+        data.resize(pos);
+
+        // 6. Decode JPEG into vita2d texture
+        vita2d_texture* tex = vita2d_load_JPEG_buffer(data.data(), data.size());
+
+        {
+            std::lock_guard<Mutex> lock(_mutex);
+            _texture = tex;
+        }
+
+        // 7. Save to folder so future opens don't need network
+        if (tex)
+        {
+            auto f = pkgi_create(_path.c_str());
+            if (f)
+            {
+                pkgi_write(f, data.data(), data.size());
+                pkgi_close(f);
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        LOGFW("ThumbnailFetcher error: {}", e.what());
+        std::lock_guard<Mutex> lock(_mutex);
+        _http = nullptr;
+    }
+}

--- a/src/thumbnailfetcher.hpp
+++ b/src/thumbnailfetcher.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "http.hpp"
+#include "thread.hpp"
+
+#ifndef PKGI_SIMULATOR
+#include <vita2d.h>
+#else
+struct vita2d_texture;
+#endif
+
+#include <string>
+
+// Fetches a game screenshot/thumbnail image.
+//
+// Resolution order (non-blocking, runs on a background thread):
+//   1. Load from  {folder}/{titleid}.jpg  if it already exists on-device.
+//   2. Download   {base_url}/{titleid}.jpg from the network (if base_url != "").
+//      Download is aborted if the file would exceed MAX_SIZE_BYTES (100 KB).
+//      On success the file is cached to {folder}/{titleid}.jpg for future use.
+//
+// The folder and base_url come from config.txt:
+//   thumbnail_folder  ux0:pkgj/thumbnails
+//   thumbnail_url     https://example.com/thumbs
+//
+// Users can also just copy JPEG files manually to the configured folder.
+class ThumbnailFetcher
+{
+public:
+    static constexpr size_t MAX_SIZE_BYTES = 100 * 1024; // 100 KB hard limit
+
+    // folder    : directory that stores the cached JPEG files
+    // base_url  : URL prefix; full URL = base_url + "/" + titleid + ".jpg"
+    //             Pass an empty string to disable network fetching.
+    ThumbnailFetcher(
+            const std::string& titleid,
+            const std::string& folder,
+            const std::string& base_url);
+    ~ThumbnailFetcher();
+
+    vita2d_texture* get_texture();
+
+private:
+    Mutex _mutex;
+
+    std::string _path;    // local file path
+    std::string _url;     // full download URL (empty = disabled)
+    bool _abort{false};
+    std::unique_ptr<Http> _http;
+    vita2d_texture* _texture{nullptr};
+
+    Thread _thread;
+
+    void do_request();
+};

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -207,6 +207,8 @@ void update_thread()
     catch (const std::exception& e)
     {
         LOGF("Update check failed: {}", e.what());
+        pkgi_dialog_error(
+                fmt::format("Update check failed: {}", e.what()).c_str());
     }
 }
 }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1,29 +1,81 @@
 #include "dialog.hpp"
+#include "curlhttp.hpp"
 #include "file.hpp"
 #include "pkgi.hpp"
-#include "vitahttp.hpp"
 
 #include <boost/scope_exit.hpp>
 
 #include <vector>
 
-#define PKGJ_UPDATE_URL "https://raw.githubusercontent.com/blastrock/pkgj/last"
-#define PKGJ_UPDATE_URL_VERSION PKGJ_UPDATE_URL "/version"
+// GitHub Releases API — latest release for toaster-code/pkgj
+#define PKGJ_RELEASES_API \
+    "https://api.github.com/repos/toaster-code/pkgj/releases/latest"
 
 namespace
 {
-std::string version;
+std::string release_tag;
+std::string download_url;
+
+// Minimal JSON string extractor: finds  "key":"value"  and returns the value.
+static std::string extract_json_str(
+        const std::string& json, const std::string& key)
+{
+    const auto search = "\"" + key + "\":\"";
+    auto pos = json.find(search);
+    if (pos == std::string::npos)
+        return {};
+    pos += search.size();
+    std::string result;
+    while (pos < json.size() && json[pos] != '"')
+    {
+        if (json[pos] == '\\' && pos + 1 < json.size())
+        {
+            ++pos;
+            if (json[pos] == '"')       result += '"';
+            else if (json[pos] == '\\') result += '\\';
+            else if (json[pos] == '/')  result += '/';
+            else                        result += json[pos];
+        }
+        else
+        {
+            result += json[pos];
+        }
+        ++pos;
+    }
+    return result;
+}
+
+// Find the browser_download_url for the first .vpk asset in a JSON releases
+// response.  The structure is: "assets":[{...,"browser_download_url":"..."}]
+static std::string find_vpk_url(const std::string& json)
+{
+    // Iterate over browser_download_url values and return first .vpk
+    size_t search_from = 0;
+    const std::string key = "\"browser_download_url\":\"";
+    while (true)
+    {
+        auto pos = json.find(key, search_from);
+        if (pos == std::string::npos)
+            return {};
+        pos += key.size();
+        std::string url;
+        while (pos < json.size() && json[pos] != '"')
+            url += json[pos++];
+        if (url.size() > 4 &&
+            url.substr(url.size() - 4) == ".vpk")
+            return url;
+        search_from = pos;
+    }
+}
 
 void start_download()
 {
     try
     {
-        LOGF("Downloading PKGj update v{}", version);
+        LOGF("Downloading PKGj update {}", release_tag);
 
         const auto filename = fmt::format(
-                "{}/pkgj-v{}.vpk", pkgi_get_config_folder(), version);
-        const auto url =
-                fmt::format("{}/pkgj-v{}.vpk", PKGJ_UPDATE_URL, version);
+                "{}/pkgj-{}.vpk", pkgi_get_config_folder(), release_tag);
 
         pkgi_dialog_message("Downloading update", 0);
 
@@ -35,8 +87,8 @@ void start_download()
                 pkgi_close(file);
             };
 
-            VitaHttp http;
-            http.start(url, 0);
+            CurlHttp http;
+            http.start(download_url, 0);
             std::vector<uint8_t> data(64 * 1024);
             while (true)
             {
@@ -81,36 +133,76 @@ void update_thread()
             pkgi_sleep(20);
         }
 
-        LOGF("Checking for updates at: {}", PKGJ_UPDATE_URL_VERSION);
+        LOGF("Checking for updates at: {}", PKGJ_RELEASES_API);
 
-        VitaHttp http;
-        http.start(PKGJ_UPDATE_URL_VERSION, 0);
-        std::vector<uint8_t> last_versionb(10);
-        last_versionb.resize(
-                http.read(last_versionb.data(), last_versionb.size()));
-        std::string last_version(last_versionb.begin(), last_versionb.end());
+        // Fetch the GitHub Releases JSON
+        CurlHttp http;
+        http.start(PKGJ_RELEASES_API, 0);
 
-        LOGF("Latest available version: {}", last_version);
-
-        if (last_version != PKGI_VERSION)
+        constexpr size_t MAX_BYTES = 256 * 1024;
+        std::vector<uint8_t> buf;
+        buf.reserve(32 * 1024);
+        size_t pos = 0;
+        while (true)
         {
-            LOG("New PKGj version available: %s", last_version.c_str());
-
-            version = last_version;
-
-            pkgi_dialog_question(
-                    fmt::format(
-                            "New PKGj version {} is available!\nDo you want to "
-                            "download it?",
-                            last_version)
-                            .c_str(),
-                    {{"Yes",
-                      [] {
-                          pkgi_start_thread(
-                                  "pkgj_update_download", &start_download);
-                      }},
-                     {"No", [] {}}});
+            if (pos == buf.size())
+                buf.resize(pos + 4096);
+            int64_t n = 0;
+            try { n = http.read(buf.data() + pos, buf.size() - pos); }
+            catch (...) { break; }
+            if (n == 0)
+                break;
+            pos += static_cast<size_t>(n);
+            if (pos > MAX_BYTES)
+                break;
         }
+        buf.resize(pos);
+
+        const std::string json(
+                reinterpret_cast<const char*>(buf.data()), buf.size());
+
+        // Parse tag_name (e.g. "v0.60") and the .vpk download URL
+        const auto tag = extract_json_str(json, "tag_name");
+        if (tag.empty())
+        {
+            LOGF("Update check: could not parse tag_name from API response");
+            return;
+        }
+
+        LOGF("Latest release: {}", tag);
+
+        // Strip leading 'v' for version comparison against PKGI_VERSION
+        const std::string tag_ver =
+                (!tag.empty() && tag[0] == 'v') ? tag.substr(1) : tag;
+
+        if (tag_ver == PKGI_VERSION)
+        {
+            LOGF("Already on latest version {}", PKGI_VERSION);
+            return;
+        }
+
+        const auto vpk_url = find_vpk_url(json);
+        if (vpk_url.empty())
+        {
+            LOGF("Update check: no .vpk asset found in release {}", tag);
+            return;
+        }
+
+        release_tag  = tag;
+        download_url = vpk_url;
+
+        pkgi_dialog_question(
+                fmt::format(
+                        "New PKGj version {} is available!\nDo you want to "
+                        "download it?",
+                        tag)
+                        .c_str(),
+                {{"Yes",
+                  [] {
+                      pkgi_start_thread(
+                              "pkgj_update_download", &start_download);
+                  }},
+                 {"No", [] {}}});
     }
     catch (const std::exception& e)
     {

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -18,7 +18,7 @@ void start_download()
 {
     try
     {
-        LOGF("starting downloading version {}", version);
+        LOGF("Downloading PKGj update v{}", version);
 
         const auto filename = fmt::format(
                 "{}/pkgj-v{}.vpk", pkgi_get_config_folder(), version);
@@ -46,11 +46,11 @@ void start_download()
                 pkgi_write(file, data.data(), read);
             }
 
-            LOGF("update download complete");
+            LOGF("PKGj update downloaded successfully");
         }
         catch (...)
         {
-            LOGF("download failed, removing partial file");
+            LOGF("PKGj update download failed, removing partial file");
             pkgi_rm(filename.c_str());
             throw;
         }
@@ -81,7 +81,7 @@ void update_thread()
             pkgi_sleep(20);
         }
 
-        LOGF("checking latest pkgi version at {}", PKGJ_UPDATE_URL_VERSION);
+        LOGF("Checking for updates at: {}", PKGJ_UPDATE_URL_VERSION);
 
         VitaHttp http;
         http.start(PKGJ_UPDATE_URL_VERSION, 0);
@@ -90,11 +90,11 @@ void update_thread()
                 http.read(last_versionb.data(), last_versionb.size()));
         std::string last_version(last_versionb.begin(), last_versionb.end());
 
-        LOGF("last version is {}", last_version);
+        LOGF("Latest available version: {}", last_version);
 
         if (last_version != PKGI_VERSION)
         {
-            LOG("new version available");
+            LOG("New PKGj version available: %s", last_version.c_str());
 
             version = last_version;
 
@@ -114,7 +114,7 @@ void update_thread()
     }
     catch (const std::exception& e)
     {
-        LOGF("error in update thread: {}", e.what());
+        LOGF("Update check failed: {}", e.what());
     }
 }
 }

--- a/src/vita.cpp
+++ b/src/vita.cpp
@@ -901,6 +901,17 @@ void pkgi_draw_text(int x, int y, uint32_t color, const char* text)
     vita2d_pgf_draw_text(g_font, x, y + 20, VITA_COLOR(color), 1.f, text);
 }
 
+void pkgi_draw_text_scale(int x, int y, uint32_t color, const char* text, float scale)
+{
+    vita2d_pgf_draw_text(
+            g_font,
+            x,
+            y + 20,
+            VITA_COLOR(color),
+            scale,
+            text);
+}
+
 int pkgi_text_width(const char* text)
 {
     return vita2d_pgf_text_width(g_font, 1.f, text);

--- a/src/vita.cpp
+++ b/src/vita.cpp
@@ -9,6 +9,7 @@ extern "C"
 #include "file.hpp"
 #include "http.hpp"
 #include "log.hpp"
+#include "logbuffer.hpp"
 #include "psx.hpp"
 
 #include <fmt/format.h>
@@ -44,10 +45,26 @@ extern "C"
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <curl/curl.h>
 
 extern "C"
 {
     int _newlib_heap_size_user = 128 * 1024 * 1024;
+
+    // libcurl calls fcntl(sock, F_SETFD, FD_CLOEXEC) on every socket it opens.
+    // PS Vita's SceNet layer does not support this and returns an error, which
+    // curl treats as fatal (CURLE_COULDNT_CONNECT). Intercept via --wrap and
+    // silently succeed for F_SETFD so curl can proceed normally.
+    int __wrap_fcntl(int /*fd*/, int cmd, ...)
+    {
+        if (cmd == F_SETFD)
+            return 0;
+        // All other fcntl uses are unsupported on Vita anyway.
+        errno = ENOSYS;
+        return -1;
+    }
 }
 
 static vita2d_pgf* g_font;
@@ -73,8 +90,7 @@ static int g_log_socket;
 
 #define PKGI_ERRNO_ENOENT (int)(0x80010000 + SCE_NET_ENOENT)
 
-#ifdef PKGI_ENABLE_LOGGING
-void pkgi_log(const char* msg, ...)
+void pkgi_log(LogLevel level, const char* msg, ...)
 {
     char buffer[512];
 
@@ -83,12 +99,20 @@ void pkgi_log(const char* msg, ...)
     // TODO: why sceClibVsnprintf doesn't work here?
     int len = vsnprintf(buffer, sizeof(buffer) - 1, msg, args);
     va_end(args);
-    buffer[len] = '\n';
+    if (len < 0)
+        len = 0;
+    else if (len >= static_cast<int>(sizeof(buffer)))
+        len = sizeof(buffer) - 1;
+    buffer[len] = 0;
 
+    pkgi_log_buffer_append(level, buffer);
+
+#ifdef PKGI_ENABLE_LOGGING
+    buffer[len] = '\n';
     sceNetSend(g_log_socket, buffer, len + 1, 0);
     // sceKernelDelayThread(10);
-}
 #endif
+}
 
 
 int pkgi_snprintf(char* buffer, uint32_t size, const char* msg, ...)
@@ -201,7 +225,7 @@ static void pkgi_start_debug_log(void)
     sceNetInetPton(SCE_NET_AF_INET, "239.255.0.100", &addr.sin_addr);
 
     sceNetConnect(g_log_socket, (SceNetSockaddr*)&addr, sizeof(addr));
-    LOG("debug logging socket initialized");
+    LOG("Debug logging socket initialized");
 #endif
 }
 
@@ -273,7 +297,7 @@ void pkgi_dialog_lock(void)
     int res = sceKernelLockLwMutex(&g_dialog_lock, 1, NULL);
     if (res < 0)
     {
-        LOG("dialog unlock failed error=0x%08x", res);
+    LOG_WARN("Dialog mutex lock failed: err=0x%08x", res);
     }
 }
 
@@ -282,7 +306,7 @@ void pkgi_dialog_unlock(void)
     int res = sceKernelUnlockLwMutex(&g_dialog_lock, 1);
     if (res < 0)
     {
-        LOG("dialog lock failed error=0x%08x", res);
+    LOG_WARN("Dialog mutex unlock failed: err=0x%08x", res);
     }
 }
 
@@ -437,7 +461,7 @@ void pkgi_dialog_input_text(const char* title, const char* text)
     int res = sceImeDialogInit(&param);
     if (res < 0)
     {
-        LOG("sceImeDialogInit failed, error 0x%08x", res);
+        LOG_ERR("IME dialog initialization failed: err=0x%08x", res);
     }
     else
     {
@@ -497,11 +521,13 @@ void pkgi_start(void)
 
     pkgi_start_debug_log();
 
-    LOG("initializing SSL");
+    LOG("Initializing SSL");
     sceSslInit(1024 * 1024);
-    LOG("initializing HTTP");
+    LOG("Initializing HTTP");
     sceHttpInit(1024 * 1024);
-    LOG("network initialized");
+    LOG("Initializing cURL");
+    curl_global_init(CURL_GLOBAL_ALL);
+    LOG("Network stack initialized");
 
     sceHttpsDisableOption(SCE_HTTPS_FLAG_SERVER_VERIFY);
 
@@ -537,7 +563,7 @@ void pkgi_start(void)
 
     if (scePromoterUtilityInit() < 0)
     {
-        LOG("cannot initialize promoter utility");
+        LOG_ERR("Failed to initialize promoter utility");
     }
 
     sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG);
@@ -567,9 +593,9 @@ void pkgi_start(void)
     g_time = sceKernelGetProcessTimeWide();
 
     sqlite3_rw_init();
-    LOG("start done");
+    LOG("Vita hardware initialization complete");
 
-    LOG("Caching PSX content id to title id list");
+    LOG("Caching PSX content ID to title ID mappings");
     pkgi_scan_pbps();
     
 }
@@ -780,7 +806,7 @@ void pkgi_start_thread(const char* name, pkgi_thread_entry* start)
             name, &pkgi_vita_thread, 0x40, 1024 * 1024, 0, 0, NULL);
     if (id < 0)
     {
-        LOG("failed to start %s thread", name);
+        LOG_ERR("Failed to start thread: %s", name);
     }
     else
     {
@@ -797,10 +823,10 @@ void pkgi_lock_process(void)
 {
     if (__atomic_fetch_add(&g_power_lock, 1, __ATOMIC_SEQ_CST) == 0)
     {
-        LOG("locking shell functionality");
+        LOG("Locking Vita shell");
         if (sceShellUtilLock(SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN) < 0)
         {
-            LOG("sceShellUtilLock failed");
+            LOG_WARN("Shell lock failed");
         }
     }
 }
@@ -809,10 +835,10 @@ void pkgi_unlock_process(void)
 {
     if (__atomic_sub_fetch(&g_power_lock, 1, __ATOMIC_SEQ_CST) == 0)
     {
-        LOG("unlocking shell functionality");
+        LOG("Unlocking Vita shell");
         if (sceShellUtilUnlock(SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN) < 0)
         {
-            LOG("sceShellUtilUnlock failed");
+            LOG_WARN("Shell unlock failed");
         }
     }
 }
@@ -823,7 +849,7 @@ pkgi_texture pkgi_load_png_raw(const void* data, uint32_t size)
     vita2d_texture* tex = vita2d_load_PNG_buffer((const char*)data);
     if (!tex)
     {
-        LOG("failed to load texture");
+        LOG_WARN("Failed to load background texture");
     }
     return tex;
 }

--- a/src/vita.cpp
+++ b/src/vita.cpp
@@ -194,6 +194,24 @@ int pkgi_is_korean_char(const unsigned int c)
     return 0;
 }
 
+int pkgi_is_japanese_char(const unsigned int c)
+{
+    unsigned short ch = c;
+    // hiragana block
+    if (0x3040 <= ch && ch <= 0x309f)
+        return 1;
+    // katakana block
+    if (0x30a0 <= ch && ch <= 0x30ff)
+        return 1;
+    // punctuation / fullwidth forms commonly used in Japanese text
+    if (0xff00 <= ch && ch <= 0xffef)
+        return 1;
+    // CJK unified ideographs
+    if (0x4e00 <= ch && ch <= 0x9fff)
+        return 1;
+    return 0;
+}
+
 int pkgi_is_latin_char(const unsigned int c)
 {
     unsigned short ch = c;
@@ -583,7 +601,8 @@ void pkgi_start(void)
     }
 
     vita2d_init_advanced(4 * 1024 * 1024);
-    vita2d_system_pgf_config pgf_confs[3] = {
+    vita2d_system_pgf_config pgf_confs[4] = {
+            {SCE_FONT_LANGUAGE_JAPANESE, pkgi_is_japanese_char},
             {SCE_FONT_LANGUAGE_KOREAN, pkgi_is_korean_char},
             {SCE_FONT_LANGUAGE_LATIN, pkgi_is_latin_char},
             {SCE_FONT_LANGUAGE_DEFAULT, NULL},

--- a/src/vita.cpp
+++ b/src/vita.cpp
@@ -903,11 +903,19 @@ void pkgi_draw_text(int x, int y, uint32_t color, const char* text)
 
 void pkgi_draw_text_scale(int x, int y, uint32_t color, const char* text, float scale)
 {
+    uint8_t alpha = static_cast<uint8_t>(color >> 24);
+    if (alpha == 0)
+        alpha = 255;
+    uint32_t rgba = RGBA8(
+            static_cast<uint8_t>(color & 0xff),
+            static_cast<uint8_t>((color >> 8) & 0xff),
+            static_cast<uint8_t>((color >> 16) & 0xff),
+            alpha);
     vita2d_pgf_draw_text(
             g_font,
             x,
-            y + 20,
-            VITA_COLOR(color),
+            y + static_cast<int>(20.f * scale),
+            rgba,
             scale,
             text);
 }

--- a/src/vitafile.cpp
+++ b/src/vitafile.cpp
@@ -29,7 +29,7 @@ void pkgi_mkdirs(const char* ppath)
 
         char last = *ptr;
         *ptr = 0;
-        LOG("mkdir %s", path.c_str());
+        LOG("Creating directory: %s", path.c_str());
         int err = sceIoMkdir(path.c_str(), 0777);
         if (err < 0 && err != PKGI_ERRNO_EEXIST)
             throw std::runtime_error(fmt::format(
@@ -46,7 +46,7 @@ void pkgi_rm(const char* file)
     int err = sceIoRemove(file);
     if (err < 0)
     {
-        LOG("error removing %s file, err=0x%08x", file, err);
+        LOG("Failed to delete file %s: err=0x%08x", file, err);
     }
 }
 
@@ -56,7 +56,7 @@ int64_t pkgi_get_size(const char* path)
     int err = sceIoGetstat(path, &stat);
     if (err < 0)
     {
-        LOG("cannot get size of %s, err=0x%08x", path, err);
+        LOG("Failed to get file size %s: err=0x%08x", path, err);
         return -1;
     }
     return stat.st_size;
@@ -99,7 +99,7 @@ void pkgi_rename(const std::string& from, const std::string& to)
 
 void* pkgi_create(const std::string& path)
 {
-    LOGF("sceIoOpen create on {}", path);
+    LOGF("Creating file: {}", path);
     SceUID fd = sceIoOpen(
             path.c_str(), SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 0777);
     if (fd < 0)
@@ -113,29 +113,29 @@ void* pkgi_create(const std::string& path)
 
 void* pkgi_openrw(const char* path)
 {
-    LOG("sceIoOpen openrw on %s", path);
+    LOG("Opening file for read/write: %s", path);
     SceUID fd = sceIoOpen(path, SCE_O_RDWR, 0777);
     if (fd < 0)
     {
-        LOG("cannot openrw %s, err=0x%08x", path, fd);
+        LOG("Failed to open %s for read/write: err=0x%08x", path, fd);
         return NULL;
     }
-    LOG("sceIoOpen returned fd=%d", fd);
+    LOG("Opened r/w fd=%d for %s", fd, path);
 
     return (void*)(intptr_t)fd;
 }
 
 void* pkgi_append(const char* path)
 {
-    LOG("sceIoOpen append on %s", path);
+    LOG("Opening file for append: %s", path);
     SceUID fd =
             sceIoOpen(path, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_APPEND, 0777);
     if (fd < 0)
     {
-        LOG("cannot append %s, err=0x%08x", path, fd);
+        LOG("Failed to open %s for append: err=0x%08x", path, fd);
         return NULL;
     }
-    LOG("sceIoOpen returned fd=%d", fd);
+    LOG("Opened append fd=%d for %s", fd, path);
 
     return (void*)(intptr_t)fd;
 }
@@ -171,11 +171,11 @@ int pkgi_write(void* f, const void* buffer, uint32_t size)
 void pkgi_close(void* f)
 {
     SceUID fd = (SceUID)(intptr_t)f;
-    LOG("closing file %d", fd);
+    LOG("Closing file descriptor: %d", fd);
     int err = sceIoClose(fd);
     if (err < 0)
     {
-        LOG("close error 0x%08x", err);
+        LOG("Failed to close file descriptor: err=0x%08x", err);
     }
 }
 

--- a/src/vitahttp.cpp
+++ b/src/vitahttp.cpp
@@ -29,7 +29,7 @@ VitaHttp::~VitaHttp()
 {
     if (_http)
     {
-        LOG("http close");
+        LOG("HTTP connection closed");
         sceHttpDeleteRequest(_http->req);
         sceHttpDeleteConnection(_http->conn);
         sceHttpDeleteTemplate(_http->tmpl);
@@ -42,7 +42,7 @@ void VitaHttp::start(const std::string& url, uint64_t offset)
     if (_http)
         throw HttpError("HTTP connection already started");
 
-    LOG("http get");
+    LOG("HTTP GET request");
 
     pkgi_http* http = NULL;
     for (size_t i = 0; i < 4; i++)
@@ -61,7 +61,7 @@ void VitaHttp::start(const std::string& url, uint64_t offset)
     int conn = -1;
     int req = -1;
 
-    LOGF("starting http GET request for {}", url);
+    LOGF("HTTP GET: {}", url);
 
     if ((tmpl = sceHttpCreateTemplate(
                  PKGI_USER_AGENT, SCE_HTTP_VERSION_1_1, SCE_TRUE)) < 0)
@@ -170,7 +170,7 @@ void VitaHttp::abort()
     {
         const auto err = sceHttpAbortRequest(_http->req);
         if (err)
-            LOGF("abort() failed: {:#08x}", static_cast<uint32_t>(err));
+            LOGFW("HTTP abort failed: err={:#08x}", static_cast<uint32_t>(err));
     }
 }
 
@@ -188,12 +188,11 @@ int64_t VitaHttp::get_length()
     if (res == (int)SCE_HTTP_ERROR_NO_CONTENT_LENGTH ||
         res == (int)SCE_HTTP_ERROR_CHUNK_ENC)
     {
-        LOG("http response has no content length (or chunked "
-            "encoding)");
+        LOG("HTTP response has no Content-Length (chunked transfer assumed)");
         return 0;
     }
 
-    LOGF("http response length = {}", content_length);
+    LOGF("HTTP Content-Length: {} bytes", content_length);
     return content_length;
 }
 
@@ -217,7 +216,7 @@ void VitaHttp::check_status()
 
     const auto status = get_status();
 
-    LOGF("http status code = {}", status);
+    LOGF("HTTP response status: {}", status);
 
     if (status != 200 && status != 206)
         throw HttpError(fmt::format("bad http status: {}", status));

--- a/src/workerpool.hpp
+++ b/src/workerpool.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "thread.hpp"
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+
+// WorkerSlot — a single-slot background worker.
+//
+// At most one task runs at a time.  The main thread submits tasks via
+// try_submit(); the worker thread runs the provided lambda entirely on
+// local data and never touches the caller's object.
+//
+// Key guarantees:
+//  • Only one background thread is alive at any time.
+//  • Submitting the same task_id while it is already running returns false
+//    (duplicate detection).  A different task also returns false while the
+//    slot is busy — the caller retries next frame.
+//  • The caller can be destroyed safely at any time: results are handed
+//    back through a shared_ptr, so even if the owner is gone the worker
+//    writes into the still-live result object and then releases it.
+class WorkerSlot
+{
+public:
+    WorkerSlot()  = default;
+    ~WorkerSlot()
+    {
+        // Join the OS thread on shutdown so no thread outlives the process.
+        if (_thread)
+            _thread->join();
+    }
+
+    WorkerSlot(const WorkerSlot&)            = delete;
+    WorkerSlot& operator=(const WorkerSlot&) = delete;
+
+    // Attempt to start a new background task.
+    //
+    // task_id  — any string that uniquely identifies this unit of work.
+    //            If the same task_id is already running the call is treated
+    //            as a duplicate (in-flight) and immediately returns false.
+    // fn       — the work function; MUST operate only on data captured by
+    //            value or through a shared_ptr.  It must NOT capture raw
+    //            pointers or references to objects that may be destroyed
+    //            before the worker finishes.
+    //
+    // Returns true  → thread started; the slot is now busy.
+    // Returns false → slot is busy (same or different task); no state change.
+    //                 The caller should retry on the next frame.
+    bool try_submit(const std::string& task_id, std::function<void()> fn)
+    {
+        if (_running.load(std::memory_order_acquire))
+        {
+            // Slot is busy.
+            // If task_id == _current_task_id this is a duplicate in-flight
+            // request; either way we cannot start another thread yet.
+            return false;
+        }
+
+        // Worker is idle.  Join (and free) the finished Thread object before
+        // creating a new one — on Vita sceKernelDeleteThread must be called
+        // after the thread has ended.
+        if (_thread)
+        {
+            _thread->join();
+            _thread.reset();
+        }
+
+        _current_task_id = task_id;
+        _running.store(true, std::memory_order_release);
+
+        // Wrap fn: after fn() returns, mark the slot idle again so the next
+        // try_submit() can start a new task on the following frame.
+        _thread = std::make_unique<Thread>(
+                "img_worker",
+                [this, fn = std::move(fn)]() mutable
+                {
+                    fn();
+                    _running.store(false, std::memory_order_release);
+                });
+
+        return true;
+    }
+
+    bool               is_running()      const { return _running.load(std::memory_order_acquire); }
+    const std::string& current_task_id() const { return _current_task_id; }
+
+    // Block until the worker is idle.  For graceful shutdown only — do not
+    // call from the main render loop.
+    void join()
+    {
+        if (_thread)
+        {
+            _thread->join();
+            _thread.reset();
+        }
+    }
+
+    // Global singleton shared by all ImageFetcher instances.
+    // Ensures at most one background download is in flight at any time.
+    static WorkerSlot& image_worker()
+    {
+        static WorkerSlot s;
+        return s;
+    }
+
+private:
+    std::unique_ptr<Thread> _thread;
+    std::atomic<bool>       _running{false};
+    std::string             _current_task_id; // written from the main thread only
+};


### PR DESCRIPTION
I've made a cleaner pull request here :)

**Main changes**
- added a linux simulator (to test the UI and some http requests)
- Annotation system: flag games with custom status (Favorite, Good, Bad, etc.)
- PSP gameview: open game details for PSP games same as Vita games
- PSM Runtime auto-download when installing a PSM game
- Redownload prompt for already-installed games
- DLC multi-select: select up to 32 DLCs before queueing (S button) (got from @Yoti fork)
- Linux simulator: full SDL2-based desktop build for development/testing
- CI: GitHub Actions pipeline for PS Vita VPK + Host Linux binaries
- CI: fix missing openssl and zstd dependencies for curl (VitaSDK conan recipe)
- CI: upgrade to ubuntu-24.04, Node.js 24, actions/checkout@v5
